### PR TITLE
query to queue patients

### DIFF
--- a/packages/rde-sync/app/api/routes.ts
+++ b/packages/rde-sync/app/api/routes.ts
@@ -148,7 +148,7 @@ export const apiRoutes: ServerRoute[] = [
     options: {
       validate: {
         payload: Joi.object({
-          patientIds: Joi.array().items(Joi.string()).required(),
+          patientIds: Joi.array().items(Joi.number().integer()).required(),
           userId: Joi.string().required(),
           reportingMonth: Joi.string().required(),
         }),


### PR DESCRIPTION
### changing base table from hiv monthly frozen to rde sync queue