### PR TITLE
(feat) Add EMT ambulance handover endpoints

### DIFF
--- a/packages/hie-saf/src/app.module.ts
+++ b/packages/hie-saf/src/app.module.ts
@@ -20,6 +20,7 @@ import { HwrSyncModule } from './hwr-sync/hwr-sync.module';
 import { BiometricsService } from './consent/biometrics/biometrics.service';
 import { ShrModule } from './shr/shr.module';
 import { CaseSummaryModule } from './case-summary/case-summary.module';
+import { EmtModule } from './emt/emt.module';
 @Module({
   imports: [
     HieAuthModule,
@@ -58,7 +59,8 @@ import { CaseSummaryModule } from './case-summary/case-summary.module';
     TypeOrmModule.forFeature([FacilityLocation]),
     HwrSyncModule,
     ShrModule,
-    CaseSummaryModule
+    CaseSummaryModule,
+    EmtModule,
   ],
   controllers: [AppController],
   providers: [

--- a/packages/hie-saf/src/emt/dto/initiate-emt-handover.dto.ts
+++ b/packages/hie-saf/src/emt/dto/initiate-emt-handover.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Notify the receiving practitioner that an EMT ambulance handover is ready
+ * to be accepted. `identifier`/`identifier_type`/`regulator` are resolved
+ * server side from the logged in provider — never accepted from the client,
+ * so the endpoint cannot be spoofed into notifying an arbitrary doctor.
+ * @see https://hie-docs.dha.go.ke/eclaims/emt-handover
+ */
+export class InitiateEmtHandoverDto {
+  @ApiProperty({
+    description: 'case_number of the referral, from GET /emt/referrals',
+    example: 'AMB-d22419d8-6d36-4b2f-a33c-3e008bd85f77-FAC',
+  })
+  @IsNotEmpty()
+  @IsString()
+  incidenceNumber!: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/emt/dto/list-emt-referrals.dto.ts
+++ b/packages/hie-saf/src/emt/dto/list-emt-referrals.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+/**
+ * List EMT ambulance referrals pending action at this facility.
+ * @see https://hie-docs.dha.go.ke/eclaims/emt-handover
+ */
+export class ListEmtReferralsDto {
+  @ApiProperty({
+    required: false,
+    description: 'Filter by referral status',
+    example: 'pending_acceptance',
+  })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  status?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Max results to return',
+    example: '50',
+  })
+  @IsOptional()
+  @IsNumberString()
+  limit?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Pagination offset',
+    example: '0',
+  })
+  @IsOptional()
+  @IsNumberString()
+  offset?: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/emt/dto/verify-emt-handover.dto.ts
+++ b/packages/hie-saf/src/emt/dto/verify-emt-handover.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Verify the OTP sent to the receiving practitioner to confirm an EMT
+ * ambulance handover.
+ * @see https://hie-docs.dha.go.ke/eclaims/emt-handover
+ */
+export class VerifyEmtHandoverDto {
+  @ApiProperty({ example: 'AMB-d22419d8-6d39-4b2f-a33c-3e008bd85f77-FAC' })
+  @IsNotEmpty()
+  @IsString()
+  incidenceNumber!: string;
+
+  @ApiProperty({
+    description: 'request_id returned by POST /emt/handover/initiate',
+    example: '82fd22b6-e366-4077-9866-e1c4ed7328b0',
+  })
+  @IsNotEmpty()
+  @IsString()
+  requestId!: string;
+
+  @ApiProperty({
+    description: 'OTP the receiving practitioner received',
+    example: '623415',
+  })
+  @IsNotEmpty()
+  @IsString()
+  otp!: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/emt/emt.controller.ts
+++ b/packages/hie-saf/src/emt/emt.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { OpenMrsAuthGuard } from '../auth/guards/openmrs-auth-guard/openmrs-auth.guard';
+import { InitiateEmtHandoverDto } from './dto/initiate-emt-handover.dto';
+import { ListEmtReferralsDto } from './dto/list-emt-referrals.dto';
+import { VerifyEmtHandoverDto } from './dto/verify-emt-handover.dto';
+import { EmtService } from './emt.service';
+
+/**
+ * DHA EMT ambulance handover — list referrals awaiting action, initiate a
+ * handover to the logged in practitioner, and verify the OTP that confirms
+ * it. The receiving practitioner's identity is always resolved server side
+ * from the OpenMRS session, never taken from the request body.
+ */
+@UseGuards(OpenMrsAuthGuard)
+@Controller('emt')
+export class EmtController {
+  constructor(private readonly emtService: EmtService) {}
+
+  @Get('referrals')
+  listReferrals(@Query() query: ListEmtReferralsDto) {
+    return this.emtService.listReferrals(query);
+  }
+
+  @Post('handover/initiate')
+  initiateHandover(
+    @Body() body: InitiateEmtHandoverDto,
+    @Req() request: Request,
+  ) {
+    return this.emtService.initiateHandover(
+      body,
+      request.cookies?.['JSESSIONID'] as string | undefined,
+    );
+  }
+
+  @Post('handover/verify')
+  verifyHandover(@Body() body: VerifyEmtHandoverDto) {
+    return this.emtService.verifyHandover(body);
+  }
+}

--- a/packages/hie-saf/src/emt/emt.module.ts
+++ b/packages/hie-saf/src/emt/emt.module.ts
@@ -1,27 +1,20 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { FacilityLocation } from '../core/database/entities/facility-locations.entity';
 import { HwrSync } from '../core/database/entities/hwr_sync.entity';
 import { HealthWorkerRegistryModule } from '../health-worker-registry/health-worker-registry.module';
 import { HealthWorkerRegistryService } from '../health-worker-registry/health-worker-registry.service';
 import { HieHttpRequestModule } from '../hie-http-request/hie-http-request.module';
-import { LocationFacilityHelper } from '../shared/utils/location-facility.helper';
-import { ShrController } from './shr.controller';
-import { ShrService } from './shr.service';
 import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
+import { EmtController } from './emt.controller';
+import { EmtService } from './emt.service';
 
 @Module({
   imports: [
     HieHttpRequestModule,
     HealthWorkerRegistryModule,
-    TypeOrmModule.forFeature([FacilityLocation, HwrSync]),
+    TypeOrmModule.forFeature([HwrSync]),
   ],
-  controllers: [ShrController],
-  providers: [
-    ShrService,
-    LocationFacilityHelper,
-    PractitionerResolver,
-    HealthWorkerRegistryService,
-  ],
+  controllers: [EmtController],
+  providers: [EmtService, PractitionerResolver, HealthWorkerRegistryService],
 })
-export class ShrModule {}
+export class EmtModule {}

--- a/packages/hie-saf/src/emt/emt.service.spec.ts
+++ b/packages/hie-saf/src/emt/emt.service.spec.ts
@@ -1,0 +1,414 @@
+import { HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { validate } from 'class-validator';
+import { HieHttpRequests } from '../hie-http-request/hie-http-requests';
+import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
+import { InitiateEmtHandoverDto } from './dto/initiate-emt-handover.dto';
+import { ListEmtReferralsDto } from './dto/list-emt-referrals.dto';
+import { VerifyEmtHandoverDto } from './dto/verify-emt-handover.dto';
+import { EmtService } from './emt.service';
+import { EmtErrorCode } from './types';
+
+const BASE_URL = 'https://ilm-dev.dha.go.ke/uat-middleware';
+
+const upstreamResponse = (body: unknown, ok = true, status = 200) => ({
+  ok,
+  status,
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+describe('EmtService', () => {
+  let service: EmtService;
+  const hieHttpRequests = {
+    sendGetRequest: jest.fn(),
+    sendPostRequest: jest.fn(),
+  };
+  const configService = { get: jest.fn() };
+  const practitionerResolver = {
+    resolveLoggedInPractitionerIdentity: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    configService.get.mockReturnValue(BASE_URL);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmtService,
+        { provide: HieHttpRequests, useValue: hieHttpRequests },
+        { provide: ConfigService, useValue: configService },
+        { provide: PractitionerResolver, useValue: practitionerResolver },
+      ],
+    }).compile();
+
+    service = module.get<EmtService>(EmtService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('listReferrals', () => {
+    it('sends only the referral filters that were supplied', async () => {
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse({ results: [], count: 0, limit: 50, offset: 0 }),
+      );
+
+      await service.listReferrals({
+        status: 'pending_acceptance',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendGetRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/api/v1/claims/emt/pending?status=pending_acceptance`,
+        'loc-1',
+      );
+    });
+
+    it('returns the parsed referrals envelope unchanged', async () => {
+      const envelope = {
+        results: [
+          {
+            submission_id: 3,
+            cr_id: 'CR5617849204955-8',
+            status: 'pending_acceptance',
+            case_number: 'AMB-d22419d8-6d36-4b2f-a33c-3e008bd85f77-FAC',
+            ambulance_fr_code: 'FID-AMB-916293-3',
+            facility_fr_code: 'FID-47-108521-3',
+            evacuation_scene: '',
+            referral_reason: '',
+            referral_category: '',
+            transport_modality: '',
+            referral_notes: 'string',
+            bundle_id: 'd22419d8-6d36-4b2f-a33c-3e008bd85f77',
+            interventions: ['SHA-01-001'],
+            requested_at: '2026-08-04T09:37:39.438967Z',
+            updated_at: '2026-08-04T09:37:40.428903Z',
+          },
+        ],
+        count: 1,
+        limit: 50,
+        offset: 0,
+      };
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse(envelope),
+      );
+
+      const result = await service.listReferrals({ locationUuid: 'loc-1' });
+
+      expect(hieHttpRequests.sendGetRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/api/v1/claims/emt/pending`,
+        'loc-1',
+      );
+      expect(result).toEqual(envelope);
+    });
+
+    it('normalizes an upstream 5xx as an upstream error', async () => {
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse({ message: 'internal error' }, false, 503),
+      );
+
+      await expect(
+        service.listReferrals({ locationUuid: 'loc-1' }),
+      ).rejects.toMatchObject({
+        status: 503,
+        response: { statusCode: 503, code: EmtErrorCode.UpstreamError },
+      });
+    });
+
+    it('normalizes a network failure/timeout as an upstream error', async () => {
+      hieHttpRequests.sendGetRequest.mockRejectedValue(
+        new Error('fetch failed'),
+      );
+
+      await expect(
+        service.listReferrals({ locationUuid: 'loc-1' }),
+      ).rejects.toMatchObject({
+        status: HttpStatus.BAD_GATEWAY,
+        response: { code: EmtErrorCode.UpstreamError },
+      });
+    });
+  });
+
+  describe('initiateHandover', () => {
+    it('resolves the receiving practitioner server side and uses it for the payload', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockResolvedValue(
+        {
+          identifier: 'A13579',
+          identifierType: 'registration_number',
+          regulator: 'KMPDC',
+        },
+      );
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ request_id: 'req-1', status: 'pending' }),
+      );
+
+      const result = await service.initiateHandover(
+        {
+          incidenceNumber: 'AMB-d22419d8-6d36-4b2f-a33c-3e008bd85f77-FAC',
+          locationUuid: 'loc-1',
+        },
+        'session-cookie-1',
+      );
+
+      expect(
+        practitionerResolver.resolveLoggedInPractitionerIdentity,
+      ).toHaveBeenCalledWith('session-cookie-1', 'loc-1');
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/api/v1/claims/emt/handover/initiate`,
+        {
+          incidence_number: 'AMB-d22419d8-6d36-4b2f-a33c-3e008bd85f77-FAC',
+          identifier: 'A13579',
+          identifier_type: 'registration_number',
+          regulator: 'KMPDC',
+        },
+        'loc-1',
+      );
+      expect(result).toEqual({ request_id: 'req-1', status: 'pending' });
+    });
+
+    it('does not call the upstream API when the practitioner cannot be resolved', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockRejectedValue(
+        new Error('no HWR record'),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'session-cookie-1',
+        ),
+      ).rejects.toThrow();
+      expect(hieHttpRequests.sendPostRequest).not.toHaveBeenCalled();
+    });
+
+    it('normalizes an auth failure', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockResolvedValue(
+        {
+          identifier: 'A1',
+          identifierType: 'registration_number',
+          regulator: 'KMPDC',
+        },
+      );
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'invalid bearer token' }, false, 401),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'cookie',
+        ),
+      ).rejects.toMatchObject({
+        status: 401,
+        response: {
+          code: EmtErrorCode.AuthFailure,
+          message: 'invalid bearer token',
+        },
+      });
+    });
+
+    it('normalizes a conflict when the handover was already initiated', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockResolvedValue(
+        {
+          identifier: 'A1',
+          identifierType: 'registration_number',
+          regulator: 'KMPDC',
+        },
+      );
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'handover already initiated' }, false, 409),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'cookie',
+        ),
+      ).rejects.toMatchObject({
+        status: 409,
+        response: { code: EmtErrorCode.Conflict },
+      });
+    });
+
+    it('normalizes a validation error', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockResolvedValue(
+        {
+          identifier: 'A1',
+          identifierType: 'registration_number',
+          regulator: 'KMPDC',
+        },
+      );
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse(
+          { message: 'incidence_number is required' },
+          false,
+          400,
+        ),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'cookie',
+        ),
+      ).rejects.toMatchObject({
+        status: 400,
+        response: { code: EmtErrorCode.ValidationError },
+      });
+    });
+
+    it('distinguishes not-found from already-handled referrals', async () => {
+      practitionerResolver.resolveLoggedInPractitionerIdentity.mockResolvedValue(
+        {
+          identifier: 'A1',
+          identifierType: 'registration_number',
+          regulator: 'KMPDC',
+        },
+      );
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'incidence number not found' }, false, 404),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'cookie',
+        ),
+      ).rejects.toMatchObject({
+        status: 404,
+        response: { code: EmtErrorCode.NotFound },
+      });
+
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'referral already accepted' }, false, 404),
+      );
+
+      await expect(
+        service.initiateHandover(
+          { incidenceNumber: 'AMB-1-FAC', locationUuid: 'loc-1' },
+          'cookie',
+        ),
+      ).rejects.toMatchObject({
+        status: 404,
+        response: { code: EmtErrorCode.AlreadyHandled },
+      });
+    });
+  });
+
+  describe('verifyHandover', () => {
+    it('maps the verify payload to snake_case and posts it', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ status: 'accepted' }),
+      );
+
+      const result = await service.verifyHandover({
+        incidenceNumber: 'AMB-1-FAC',
+        requestId: 'req-1',
+        otp: '623415',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/api/v1/claims/emt/handover/verify`,
+        { incidence_number: 'AMB-1-FAC', request_id: 'req-1', otp: '623415' },
+        'loc-1',
+      );
+      expect(result).toEqual({ status: 'accepted' });
+    });
+
+    it('normalizes an invalid otp', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'invalid otp' }, false, 400),
+      );
+
+      await expect(
+        service.verifyHandover({
+          incidenceNumber: 'AMB-1-FAC',
+          requestId: 'req-1',
+          otp: '000000',
+          locationUuid: 'loc-1',
+        }),
+      ).rejects.toMatchObject({
+        status: 400,
+        response: { code: EmtErrorCode.InvalidOtp },
+      });
+    });
+
+    it('distinguishes an expired otp from an invalid otp', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'otp expired' }, false, 400),
+      );
+
+      await expect(
+        service.verifyHandover({
+          incidenceNumber: 'AMB-1-FAC',
+          requestId: 'req-1',
+          otp: '000000',
+          locationUuid: 'loc-1',
+        }),
+      ).rejects.toMatchObject({
+        status: 400,
+        response: { code: EmtErrorCode.OtpExpired },
+      });
+    });
+
+    it('does not classify a non-otp validation error on verify as an otp error', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ message: 'request_id is required' }, false, 400),
+      );
+
+      await expect(
+        service.verifyHandover({
+          incidenceNumber: 'AMB-1-FAC',
+          requestId: 'req-1',
+          otp: '000000',
+          locationUuid: 'loc-1',
+        }),
+      ).rejects.toMatchObject({
+        status: 400,
+        response: { code: EmtErrorCode.ValidationError },
+      });
+    });
+  });
+
+  describe('DTO validation', () => {
+    it('rejects ListEmtReferralsDto without locationUuid', async () => {
+      const dto = Object.assign(new ListEmtReferralsDto(), {
+        status: 'pending_acceptance',
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((error) => error.property === 'locationUuid')).toBe(
+        true,
+      );
+    });
+
+    it('rejects InitiateEmtHandoverDto without locationUuid', async () => {
+      const dto = Object.assign(new InitiateEmtHandoverDto(), {
+        incidenceNumber: 'AMB-1-FAC',
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((error) => error.property === 'locationUuid')).toBe(
+        true,
+      );
+    });
+
+    it('rejects VerifyEmtHandoverDto without locationUuid', async () => {
+      const dto = Object.assign(new VerifyEmtHandoverDto(), {
+        incidenceNumber: 'AMB-1-FAC',
+        requestId: 'req-1',
+        otp: '123456',
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((error) => error.property === 'locationUuid')).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/packages/hie-saf/src/emt/emt.service.ts
+++ b/packages/hie-saf/src/emt/emt.service.ts
@@ -1,0 +1,221 @@
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HieHttpRequests } from '../hie-http-request/hie-http-requests';
+import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
+import { InitiateEmtHandoverDto } from './dto/initiate-emt-handover.dto';
+import { ListEmtReferralsDto } from './dto/list-emt-referrals.dto';
+import { VerifyEmtHandoverDto } from './dto/verify-emt-handover.dto';
+import {
+  EmtErrorCode,
+  EmtInitiateHandoverApiResponse,
+  EmtInitiateHandoverPayload,
+  EmtNormalizedError,
+  EmtReferralsApiResponse,
+  EmtVerifyHandoverApiResponse,
+  EmtVerifyHandoverPayload,
+} from './types';
+
+/**
+ * DHA EMT ambulance handover middleware, on the same host as eClaims
+ * (`HIE_CLIAMS_BASE_URL`). Non-2xx upstream responses are normalized into
+ * `{ statusCode, code, message }` (thrown as the HttpException body) so the
+ * frontend can branch on `code` instead of parsing upstream error text.
+ * @see https://hie-docs.dha.go.ke/eclaims/emt-handover
+ */
+@Injectable()
+export class EmtService {
+  constructor(
+    private readonly hieHttpRequests: HieHttpRequests,
+    private readonly configService: ConfigService,
+    private readonly practitionerResolver: PractitionerResolver,
+  ) {}
+
+  /** GET /claims/emt/pending — referrals awaiting action at this facility. */
+  async listReferrals(
+    dto: ListEmtReferralsDto,
+  ): Promise<EmtReferralsApiResponse> {
+    const encodedParams = new URLSearchParams();
+    if (dto.status) {
+      encodedParams.set('status', dto.status);
+    }
+    if (dto.limit) {
+      encodedParams.set('limit', dto.limit);
+    }
+    if (dto.offset) {
+      encodedParams.set('offset', dto.offset);
+    }
+    const query = encodedParams.toString();
+    Logger.log(`Listing EMT referrals for location ${dto.locationUuid}`);
+    return this.get<EmtReferralsApiResponse>(
+      `/api/v1/claims/emt/pending${query ? `?${query}` : ''}`,
+      dto.locationUuid,
+      'list emt referrals',
+    );
+  }
+
+  /**
+   * POST /claims/emt/handover/initiate — notify the receiving practitioner
+   * that an ambulance handover is ready to accept. The practitioner's
+   * `identifier`/`identifier_type`/`regulator` are resolved server side from
+   * `sessionCookie`, never taken from the request body.
+   */
+  async initiateHandover(
+    dto: InitiateEmtHandoverDto,
+    sessionCookie: string | undefined,
+  ): Promise<EmtInitiateHandoverApiResponse> {
+    const practitioner =
+      await this.practitionerResolver.resolveLoggedInPractitionerIdentity(
+        sessionCookie,
+        dto.locationUuid,
+      );
+    const payload: EmtInitiateHandoverPayload = {
+      incidence_number: dto.incidenceNumber,
+      identifier: practitioner.identifier,
+      identifier_type: practitioner.identifierType,
+      regulator: practitioner.regulator,
+    };
+    Logger.log(`Initiating EMT handover for incidence ${dto.incidenceNumber}`);
+    return this.post<EmtInitiateHandoverApiResponse>(
+      '/api/v1/claims/emt/handover/initiate',
+      payload,
+      dto.locationUuid,
+      'initiate emt handover',
+    );
+  }
+
+  /** POST /claims/emt/handover/verify — exchange the OTP to confirm the handover. */
+  async verifyHandover(
+    dto: VerifyEmtHandoverDto,
+  ): Promise<EmtVerifyHandoverApiResponse> {
+    const payload: EmtVerifyHandoverPayload = {
+      incidence_number: dto.incidenceNumber,
+      request_id: dto.requestId,
+      otp: dto.otp,
+    };
+    Logger.log(
+      `Verifying EMT handover OTP for incidence ${dto.incidenceNumber}`,
+    );
+    return this.post<EmtVerifyHandoverApiResponse>(
+      '/api/v1/claims/emt/handover/verify',
+      payload,
+      dto.locationUuid,
+      'verify emt handover',
+    );
+  }
+
+  private claimsBaseUrl(): string {
+    return this.configService.get<string>('HIE_CLIAMS_BASE_URL') ?? '';
+  }
+
+  private async get<T>(
+    path: string,
+    locationUuid: string,
+    context: string,
+  ): Promise<T> {
+    try {
+      const response = await this.hieHttpRequests.sendGetRequest(
+        `${this.claimsBaseUrl()}${path}`,
+        locationUuid,
+      );
+      return await this.readResponse<T>(response, context);
+    } catch (error) {
+      throw this.asHttpException(error, context);
+    }
+  }
+
+  private async post<T>(
+    path: string,
+    payload: any,
+    locationUuid: string,
+    context: string,
+  ): Promise<T> {
+    try {
+      const response: Response = await this.hieHttpRequests.sendPostRequest(
+        `${this.claimsBaseUrl()}${path}`,
+        payload,
+        locationUuid,
+      );
+      return await this.readResponse<T>(response, context);
+    } catch (error) {
+      throw this.asHttpException(error, context);
+    }
+  }
+
+  private async readResponse<T>(
+    response: Response,
+    context: string,
+  ): Promise<T> {
+    const text = await response.text();
+    let data: unknown = null;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!response.ok) {
+      const message =
+        typeof data === 'object' && data && 'message' in data
+          ? (data as { message: string }).message
+          : (typeof data === 'string' && data) ||
+            `EMT ${context} failed (${response.status})`;
+      Logger.error(
+        `EMT ${context} ${response.status}: ${typeof data === 'string' ? data : JSON.stringify(data)}`,
+      );
+      const normalized = this.normalizeError(response.status, message);
+      throw new HttpException(normalized, normalized.statusCode);
+    }
+    return (data ?? {}) as T;
+  }
+
+  /**
+   * Maps an upstream status + message to a stable `{ statusCode, code,
+   * message }` shape. `statusCode` preserves the upstream HTTP status (so
+   * generic HTTP tooling still behaves sanely); `code` is the fine-grained
+   * category the frontend actually branches on. OTP-specific codes are
+   * detected from the message text (rather than which endpoint was called)
+   * since a 400 on verify can also be a plain validation error, e.g. a
+   * missing `request_id`.
+   */
+  private normalizeError(status: number, message: string): EmtNormalizedError {
+    const statusCode =
+      status >= 400 && status < 600 ? status : HttpStatus.BAD_GATEWAY;
+    const lowerMessage = message.toLowerCase();
+    let code = EmtErrorCode.Unknown;
+    if (status === 401 || status === 403) {
+      code = EmtErrorCode.AuthFailure;
+    } else if (status === 404) {
+      code = /already|handled|accepted|rejected|closed/.test(lowerMessage)
+        ? EmtErrorCode.AlreadyHandled
+        : EmtErrorCode.NotFound;
+    } else if (status === 409) {
+      code = EmtErrorCode.Conflict;
+    } else if (
+      (status === 400 || status === 422) &&
+      lowerMessage.includes('otp')
+    ) {
+      code = lowerMessage.includes('expired')
+        ? EmtErrorCode.OtpExpired
+        : EmtErrorCode.InvalidOtp;
+    } else if (status === 400 || status === 422) {
+      code = EmtErrorCode.ValidationError;
+    } else if (status >= 500) {
+      code = EmtErrorCode.UpstreamError;
+    }
+    return { statusCode, code, message };
+  }
+
+  private asHttpException(error: unknown, context: string): HttpException {
+    if (error instanceof HttpException) {
+      return error;
+    }
+    Logger.error(error);
+    const normalized: EmtNormalizedError = {
+      statusCode: HttpStatus.BAD_GATEWAY,
+      code: EmtErrorCode.UpstreamError,
+      message: `Error trying to ${context}: ${(error as Error)?.message ?? error}`,
+    };
+    return new HttpException(normalized, normalized.statusCode);
+  }
+}

--- a/packages/hie-saf/src/emt/types/index.ts
+++ b/packages/hie-saf/src/emt/types/index.ts
@@ -1,0 +1,88 @@
+/**
+ * DHA EMT ambulance handover middleware contracts, on the eClaims host
+ * (`HIE_CLIAMS_BASE_URL`).
+ * @see https://hie-docs.dha.go.ke/eclaims/emt-handover
+ */
+
+export type EmtReferral = {
+  submission_id: number;
+  cr_id: string;
+  status: string;
+  case_number: string;
+  ambulance_fr_code: string;
+  facility_fr_code: string;
+  evacuation_scene: string;
+  referral_reason: string;
+  referral_category: string;
+  transport_modality: string;
+  referral_notes: string;
+  bundle_id: string;
+  interventions: string[];
+  requested_at: string;
+  updated_at: string;
+};
+
+/** GET /claims/emt/pending response. */
+export type EmtReferralsApiResponse = {
+  results: EmtReferral[];
+  count: number;
+  limit: number;
+  offset: number;
+};
+
+/** POST /claims/emt/handover/initiate body. */
+export type EmtInitiateHandoverPayload = {
+  incidence_number: string;
+  identifier: string;
+  identifier_type: string;
+  regulator: string;
+};
+
+/**
+ * POST /claims/emt/handover/initiate response. Not fully documented upstream —
+ * `request_id` is the field the verify step needs back; everything else
+ * passes through unchanged.
+ */
+export type EmtInitiateHandoverApiResponse = {
+  request_id?: string;
+  message?: string;
+  status?: string;
+  [key: string]: any;
+};
+
+/** POST /claims/emt/handover/verify body. */
+export type EmtVerifyHandoverPayload = {
+  incidence_number: string;
+  request_id: string;
+  otp: string;
+};
+
+/** POST /claims/emt/handover/verify response — not fully documented upstream. */
+export type EmtVerifyHandoverApiResponse = {
+  message?: string;
+  status?: string;
+  [key: string]: any;
+};
+
+/**
+ * Machine readable error categories the frontend can branch on, since
+ * upstream messages/status codes alone aren't a stable contract.
+ */
+export enum EmtErrorCode {
+  AuthFailure = 'auth_failure',
+  NotFound = 'not_found',
+  AlreadyHandled = 'already_handled',
+  Conflict = 'conflict',
+  ValidationError = 'validation_error',
+  InvalidOtp = 'invalid_otp',
+  OtpExpired = 'otp_expired',
+  UpstreamError = 'upstream_error',
+  Unknown = 'unknown',
+}
+
+/** Normalized shape thrown (as the HttpException body) for every non-2xx EMT response. */
+export type EmtNormalizedError = {
+  statusCode: number;
+  code: EmtErrorCode;
+  message: string;
+};

--- a/packages/hie-saf/src/health-worker-registry/health-worker-registry.service.ts
+++ b/packages/hie-saf/src/health-worker-registry/health-worker-registry.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { HieHttpRequests } from 'src/hie-http-request/hie-http-requests';
+import { HieHttpRequests } from '../hie-http-request/hie-http-requests';
 import { FetchHealthWorkerDto } from './dto/fetch-health-worker.dto';
 import { HealthWokerApiResponse } from './types';
 

--- a/packages/hie-saf/src/shared/types/index.ts
+++ b/packages/hie-saf/src/shared/types/index.ts
@@ -42,8 +42,7 @@ export type TiberbuRequestOtpApiResponse = {
   maskedPhone: string;
 };
 export type ValidateConsentApiResponse =
-  | ValidateConsentApiSuccessResponse
-  | ValidateConsentApiErrorResponse;
+  ValidateConsentApiSuccessResponse | ValidateConsentApiErrorResponse;
 export type ValidateConsentApiSuccessResponse = {
   token: string;
   issued: number;
@@ -93,4 +92,31 @@ export type ProviderAttribute = {
 export type AttributeDto = {
   attributeType: string;
   value: string;
+};
+
+/** OpenMRS shapes used to resolve the logged in provider. */
+export type OpenMrsProvider = {
+  uuid: string;
+  identifier?: string;
+};
+
+export type OpenMrsSessionWithProvider = {
+  authenticated: boolean;
+  user?: { uuid: string; display?: string } | null;
+  currentProvider?: OpenMrsProvider | null;
+};
+
+export type OpenMrsProviderSearchResponse = {
+  results?: OpenMrsProvider[];
+};
+
+/**
+ * Regulator identity resolved for the logged in practitioner — used where a
+ * request must carry the practitioner's own registration details (e.g. EMT
+ * handover-initiate) rather than just an HWR id.
+ */
+export type ResolvedPractitionerIdentity = {
+  identifier: string;
+  identifierType: 'registration_number';
+  regulator: string;
 };

--- a/packages/hie-saf/src/shared/utils/practitioner-resolver.helper.ts
+++ b/packages/hie-saf/src/shared/utils/practitioner-resolver.helper.ts
@@ -6,17 +6,21 @@ import { HwrSync } from '../../core/database/entities/hwr_sync.entity';
 import { HealthWorkerRegistryService } from '../../health-worker-registry/health-worker-registry.service';
 import {
   HealthWokerApiResponse,
+  Message,
   Regulators,
 } from '../../health-worker-registry/types';
-import { IdentifierTypes } from '../../shared/types';
 import {
+  IdentifierTypes,
   OpenMrsProviderSearchResponse,
   OpenMrsSessionWithProvider,
+  ResolvedPractitionerIdentity,
 } from '../types';
 
 /**
- * Resolves `practitioner_id` for SHR reads from the logged in provider, the way
- * `LocationFacilityHelper` resolves `facility_id` from a location.
+ * Resolves the logged in provider's identity from the Health Worker Registry —
+ * `practitioner_id` for SHR reads, and the full registration identity for EMT
+ * handover-initiate — the way `LocationFacilityHelper` resolves `facility_id`
+ * from a location.
  *
  * Chain: JSESSIONID -> OpenMRS session (`currentProvider`, else the provider
  * linked to the session user) -> `hwr_sync.national_id` for that provider ->
@@ -29,6 +33,8 @@ import {
  *    has run (see `HwrSyncService`).
  *  - DHA's "Health Worker Registry identifier" is read as the HWR record id,
  *    falling back to the regulator registration number.
+ *  - EMT handover-initiate's `regulator` is hardcoded to KMPDC, matching the
+ *    only regulator this resolver currently queries against.
  */
 @Injectable()
 export class PractitionerResolver {
@@ -47,6 +53,53 @@ export class PractitionerResolver {
     sessionCookie: string | undefined,
     locationUuid: string,
   ): Promise<string> {
+    const healthWorker = await this.resolveHealthWorker(
+      sessionCookie,
+      locationUuid,
+    );
+    const practitionerId =
+      healthWorker.membership?.id || healthWorker.membership?.registration_id;
+    if (!practitionerId) {
+      throw new HttpException(
+        'Health Worker Registry record has no practitioner identifier',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    return practitionerId;
+  }
+
+  /**
+   * Full regulator identity for the logged in practitioner — used where a
+   * request must carry `identifier`/`identifier_type`/`regulator` rather than
+   * just an HWR id (e.g. EMT handover-initiate). Never take these values from
+   * the client; resolve them here instead.
+   */
+  public async resolveLoggedInPractitionerIdentity(
+    sessionCookie: string | undefined,
+    locationUuid: string,
+  ): Promise<ResolvedPractitionerIdentity> {
+    const healthWorker = await this.resolveHealthWorker(
+      sessionCookie,
+      locationUuid,
+    );
+    const registrationId = healthWorker.membership?.registration_id;
+    if (!registrationId) {
+      throw new HttpException(
+        'Health Worker Registry record has no registration number',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    return {
+      identifier: registrationId,
+      identifierType: 'registration_number',
+      regulator: 'KMPDC',
+    };
+  }
+
+  private async resolveHealthWorker(
+    sessionCookie: string | undefined,
+    locationUuid: string,
+  ): Promise<Message> {
     if (!sessionCookie) {
       throw new HttpException(
         'Cannot resolve the logged in practitioner: OpenMRS session cookie (JSESSIONID) is missing',
@@ -55,7 +108,7 @@ export class PractitionerResolver {
     }
     const providerUuid = await this.getLoggedInProviderUuid(sessionCookie);
     const nationalId = await this.getProviderNationalId(providerUuid);
-    return this.getRegistryPractitionerId(nationalId, locationUuid);
+    return this.getRegistryHealthWorker(nationalId, locationUuid);
   }
 
   private async getLoggedInProviderUuid(
@@ -101,7 +154,7 @@ export class PractitionerResolver {
 
   private async getProviderNationalId(providerUuid: string): Promise<string> {
     const hwr = await this.hwrSyncRepository.findOneBy({
-      provider_uuid: "b408cf01-5bcc-4c73-bfa6-88fc3cfc29c9",
+      provider_uuid: providerUuid,
     });
     if (!hwr?.national_id) {
       throw new HttpException(
@@ -112,10 +165,10 @@ export class PractitionerResolver {
     return hwr.national_id;
   }
 
-  private async getRegistryPractitionerId(
+  private async getRegistryHealthWorker(
     nationalId: string,
     locationUuid: string,
-  ): Promise<string> {
+  ): Promise<Message> {
     const response: HealthWokerApiResponse =
       await this.healthWorkerRegistryService.fetchHealthWorkerFromRegistry({
         identifierNumber: nationalId,
@@ -133,15 +186,7 @@ export class PractitionerResolver {
         HttpStatus.NOT_FOUND,
       );
     }
-    const practitionerId =
-      healthWorker.membership?.id || healthWorker.membership?.registration_id;
-    if (!practitionerId) {
-      throw new HttpException(
-        'Health Worker Registry record has no practitioner identifier',
-        HttpStatus.NOT_FOUND,
-      );
-    }
-    return practitionerId;
+    return healthWorker;
   }
 
   private async getFromOpenMrs<T>(
@@ -149,7 +194,6 @@ export class PractitionerResolver {
     sessionCookie: string,
     context: string,
   ): Promise<T> {
-    console.log("sessionCookie", sessionCookie);
     try {
       const response = await fetch(url, {
         method: 'GET',

--- a/packages/hie-saf/src/shr/shr.controller.ts
+++ b/packages/hie-saf/src/shr/shr.controller.ts
@@ -25,7 +25,7 @@ import { SubmitShrBundleDto } from './dto/submit-shr-bundle.dto';
 import { SubmitShrBundleQueryDto } from './dto/submit-shr-bundle-query.dto';
 import { VerifyShrConsentDto } from './dto/verify-shr-consent.dto';
 import { CONSENT_TOKEN_HEADER, ShrService } from './shr.service';
-import { PractitionerResolver } from './utils/practitioner-resolver.helper';
+import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
 
 /**
  * Shared Health Record read/write path. Consent tokens are handed back to

--- a/packages/hie-saf/src/shr/types/index.ts
+++ b/packages/hie-saf/src/shr/types/index.ts
@@ -89,19 +89,3 @@ export type ShrSubmitBundleApiResponse = {
 
 /** FHIR search Bundle / security labels — passed through from DHA unchanged. */
 export type ShrPassthroughResponse = Record<string, any>;
-
-/** OpenMRS shapes used to resolve the logged in provider. */
-export type OpenMrsProvider = {
-  uuid: string;
-  identifier?: string;
-};
-
-export type OpenMrsSessionWithProvider = {
-  authenticated: boolean;
-  user?: { uuid: string; display?: string } | null;
-  currentProvider?: OpenMrsProvider | null;
-};
-
-export type OpenMrsProviderSearchResponse = {
-  results?: OpenMrsProvider[];
-};


### PR DESCRIPTION
## Summary

Adds three endpoints wrapping the DHA EMT ambulance handover middleware, following the `shr` module's structure and conventions (PR #166) file-for-file:

- `GET /emt/referrals` → upstream `GET /api/v1/claims/emt/pending`
- `POST /emt/handover/initiate` → upstream `POST /api/v1/claims/emt/handover/initiate`
- `POST /emt/handover/verify` → upstream `POST /api/v1/claims/emt/handover/verify`

New module: `packages/hie-saf/src/emt/` (`emt.module.ts`, `emt.controller.ts`, `emt.service.ts`, `emt.service.spec.ts`, `dto/`, `types/index.ts`), wired into `app.module.ts` — mirrors `src/shr/`, the repo's own documented "template module" for new middleware wrappers.

**Security model**: `InitiateEmtHandoverDto` only accepts `incidenceNumber` + `locationUuid`. The receiving practitioner's `identifier`/`identifier_type`/`regulator` are always resolved server-side from the OpenMRS session inside `EmtService.initiateHandover`, never accepted from the client — verified in `emt.service.spec.ts` ("resolves the receiving practitioner server side...", "does not call the upstream API when the practitioner cannot be resolved").

**Error normalization**: non-2xx upstream responses are mapped to `{ statusCode, code, message }` (thrown as the `HttpException` body), with `code` one of `auth_failure`, `not_found`, `already_handled`, `conflict`, `validation_error`, `invalid_otp`, `otp_expired`, `upstream_error`, `unknown` — `statusCode` preserves the real upstream HTTP status. OTP-specific codes are detected from the upstream message text rather than by endpoint, since a 400 on `verify` can also be a plain validation error (e.g. missing `request_id`).

