### PR TITLE
feat: enhance SHR service with consent management and visit handling

### DIFF
--- a/packages/hie-saf/src/core/database/db.module.ts
+++ b/packages/hie-saf/src/core/database/db.module.ts
@@ -13,6 +13,7 @@ import { PreAuthRequest } from './entities/pre-auth-request.entity';
 import { ClaimPayerStateTransitionEntity } from './entities/claim-payer-preview-state-transition.entity';
 import { ClaimProviderStateTransitionEntity } from './entities/claim-provider-state-transition.entity';
 import { PreauthProviderStateTransitionEntity } from './entities/preauth-provider-state-transition.entity';
+import { ShrConsentSession } from './entities/shr-consent-session.entity';
 
 /** Name of the read-only AMRS OpenMRS connection — see `CaseSummaryModule`. */
 export const AMRS_CONNECTION = 'amrsConnection';
@@ -42,6 +43,7 @@ export const AMRS_CONNECTION = 'amrsConnection';
           ClaimPayerStateTransitionEntity,
           ClaimProviderStateTransitionEntity,
           PreauthProviderStateTransitionEntity,
+          ShrConsentSession,
         ],
         poolSize: configService.get<number>('DATABASE_POOL_SIZE'),
         synchronize: false,

--- a/packages/hie-saf/src/core/database/entities/shr-consent-session.entity.ts
+++ b/packages/hie-saf/src/core/database/entities/shr-consent-session.entity.ts
@@ -1,0 +1,101 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ShrConsentSessionStatus } from '../../../shr/types';
+
+/**
+ * An SHR consent that is currently open for a patient at a facility, so a
+ * "check or refresh my token" call does not need the caller to already be
+ * holding `visit_id`/`consent_id`.
+ *
+ * `(cr_id, location_uuid)` is the practical lookup key — it matches how DHA
+ * scopes `GET /shr/open-visits` itself. `visit_id` is unique: a visit has one
+ * active session.
+ *
+ * Written whenever DHA actually issues a usable `consent_token` (OTP approval,
+ * or an emergency consent approved on the spot), updated on refresh, and closed
+ * once a closure really completes. See `ShrConsentSessionStore`.
+ *
+ * `synchronize` is off and this repo has no migrations, so the table is created
+ * by hand:
+ *
+ * ```sql
+ * CREATE TABLE shr_consent_session (
+ *   id              INT AUTO_INCREMENT PRIMARY KEY,
+ *   cr_id           VARCHAR(100) NOT NULL,
+ *   location_uuid   VARCHAR(255) NOT NULL,
+ *   consent_id      VARCHAR(100) NULL,
+ *   visit_id        VARCHAR(255) NOT NULL,
+ *   consent_token   TEXT NOT NULL,
+ *   status          VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *   token_issued_at DATETIME     NOT NULL,
+ *   token_expires_at DATETIME    NULL,
+ *   date_created    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *   UNIQUE KEY shr_consent_session_visit_id (visit_id),
+ *   KEY shr_consent_session_cr_id (cr_id),
+ *   KEY shr_consent_session_location_uuid (location_uuid)
+ * );
+ * ```
+ *
+ * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
+ */
+@Entity({ name: 'shr_consent_session' })
+export class ShrConsentSession {
+  @PrimaryGeneratedColumn({ type: 'int' })
+  id!: number;
+
+  @Column({ type: 'varchar', length: 100, name: 'cr_id', nullable: false })
+  @Index('shr_consent_session_cr_id')
+  crId!: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'location_uuid',
+    nullable: false,
+  })
+  @Index('shr_consent_session_location_uuid')
+  locationUuid!: string;
+
+  /**
+   * Null only when the session was reconstructed from `GET /shr/open-visits`,
+   * which returns visit ids and nothing else.
+   */
+  @Column({ type: 'varchar', length: 100, name: 'consent_id', nullable: true })
+  consentId!: string | null;
+
+  @Column({ type: 'varchar', length: 255, name: 'visit_id', nullable: false })
+  @Index('shr_consent_session_visit_id', { unique: true })
+  visitId!: string;
+
+  /** DHA's per-visit JWT. Long enough that `varchar` is not safe. */
+  @Column({ type: 'text', name: 'consent_token', nullable: false })
+  consentToken!: string;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    name: 'status',
+    nullable: false,
+    default: ShrConsentSessionStatus.Open,
+  })
+  status!: ShrConsentSessionStatus;
+
+  @Column({ type: 'datetime', name: 'token_issued_at', nullable: false })
+  tokenIssuedAt!: Date;
+
+  /**
+   * The token's own `exp` claim, decoded — not a locally invented expiry. Null
+   * when the token carries no `exp`, which means staleness cannot be judged
+   * locally and the token has to be refreshed before use.
+   */
+  @Column({ type: 'datetime', name: 'token_expires_at', nullable: true })
+  tokenExpiresAt!: Date | null;
+
+  @CreateDateColumn({ type: 'timestamp', name: 'date_created' })
+  dateCreated!: Date;
+}

--- a/packages/hie-saf/src/shr/dto/close-shr-visit.dto.ts
+++ b/packages/hie-saf/src/shr/dto/close-shr-visit.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import { ShrFlag } from '../types';
+
+/**
+ * Close an SHR visit. The body beyond `locationUuid` is optional in full:
+ * omitting it keeps the default behaviour, where DHA sends a closure OTP and
+ * the visit stays open until that password is verified.
+ *
+ * `patientIncapable: 1` closes the visit immediately instead, for a patient who
+ * cannot consent to the closure themselves — unconscious or deceased.
+ *
+ * Polarity warning: this is `patient_incapable`, the *inverse* of
+ * `patient_capable` on `RequestShrConsentDto`. `patientIncapable: 1` here and
+ * `patientCapable: 0` there both mean "the patient cannot consent".
+ *
+ * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
+ */
+export class CloseShrVisitDto {
+  @ApiProperty({
+    required: false,
+    enum: [ShrFlag.No, ShrFlag.Yes],
+    description:
+      '1 when the patient cannot consent to closing the visit. The visit then closes immediately, with no OTP. Requires incapacityReason.',
+  })
+  @ValidateIf(
+    (dto: CloseShrVisitDto) =>
+      dto.patientIncapable !== undefined || dto.incapacityReason !== undefined,
+  )
+  @IsIn([ShrFlag.No, ShrFlag.Yes], {
+    message: 'patientIncapable must be 0 or 1',
+  })
+  patientIncapable?: ShrFlag;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Why the patient cannot consent to the closure. Required when patientIncapable is 1.',
+    example: 'Unconscious',
+  })
+  @ValidateIf(
+    (dto: CloseShrVisitDto) =>
+      dto.patientIncapable === ShrFlag.Yes ||
+      dto.incapacityReason !== undefined,
+  )
+  @IsNotEmpty({
+    message: 'incapacityReason is required when patientIncapable is 1',
+  })
+  @IsString()
+  incapacityReason?: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/shr/dto/get-active-consent.dto.ts
+++ b/packages/hie-saf/src/shr/dto/get-active-consent.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Ask for a ready-to-use consent token for a patient at a facility, without the
+ * caller having to hold `visit_id` or `consent_id` itself.
+ *
+ * Answered from the locally recorded consent session where possible, and
+ * otherwise by asking DHA for the patient's open visits and refreshing one —
+ * see `ShrService.getActiveConsent`.
+ *
+ * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
+ */
+export class GetActiveConsentDto {
+  @ApiProperty({ description: 'Client Registry identifier of the patient' })
+  @IsNotEmpty()
+  @IsString()
+  crId!: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/shr/dto/list-open-visits.dto.ts
+++ b/packages/hie-saf/src/shr/dto/list-open-visits.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * List the visits at a facility that still hold an open consent for a patient.
+ * `facility_id` is resolved server side from `locationUuid`, the same way the
+ * consent request resolves it.
+ *
+ * Worth calling before starting a fresh consent request: a patient who already
+ * has an open visit here cannot start another, and its token can be refreshed
+ * instead of putting the patient through a second OTP.
+ *
+ * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
+ */
+export class ListOpenVisitsDto {
+  @ApiProperty({ description: 'Client Registry identifier of the patient' })
+  @IsNotEmpty()
+  @IsString()
+  crId!: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  locationUuid!: string;
+}

--- a/packages/hie-saf/src/shr/dto/request-shr-consent.dto.ts
+++ b/packages/hie-saf/src/shr/dto/request-shr-consent.dto.ts
@@ -1,10 +1,28 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
-import { ShrVisitType } from '../types';
+import {
+  IsEnum,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
+import { ShrFlag, ShrRepresentativeRelationship, ShrVisitType } from '../types';
 
 /**
  * Request a patient's consent for an SHR visit.
- * `facility_id` is resolved server side from `locationUuid`.
+ * `facility_id` is resolved server side from `locationUuid`, and
+ * `practitioner_id` from the logged in provider — neither is taken from the
+ * client.
+ *
+ * Three shapes share this DTO:
+ *  - **standard** — the four required fields
+ *  - **emergency** — `emergency: 1` plus `incapacityReason`; approved on the
+ *    spot, so the response carries a token instead of an OTP record
+ *  - **dependant** — `representativeCrId` + `representativeRelationship`, for a
+ *    minor or an incapacitated adult; the OTP goes to the representative
+ *
  * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
  */
 export class RequestShrConsentDto {
@@ -22,6 +40,94 @@ export class RequestShrConsentDto {
   @IsNotEmpty()
   @IsEnum(ShrVisitType)
   visitType!: ShrVisitType;
+
+  @ApiProperty({
+    required: false,
+    enum: [ShrFlag.No, ShrFlag.Yes],
+    description:
+      '1 for an emergency consent — the patient is incapacitated and consent cannot be collected at the point of care. Approved immediately, with no OTP. incapacityReason is required alongside it.',
+  })
+  @IsOptional()
+  @IsIn([ShrFlag.No, ShrFlag.Yes])
+  emergency?: ShrFlag;
+
+  /**
+   * Required for an emergency consent, and for a dependant request where the
+   * patient is an incapacitated adult. Whether the patient is a minor is not
+   * knowable here, so DHA has the final say on that case — the check below only
+   * enforces what is unambiguous.
+   */
+  @ApiProperty({
+    required: false,
+    description:
+      'Why the patient cannot consent for themselves. Required when emergency is 1.',
+    example: 'Unconscious on arrival',
+  })
+  @ValidateIf(
+    (dto: RequestShrConsentDto) =>
+      dto.emergency === ShrFlag.Yes || dto.incapacityReason !== undefined,
+  )
+  @IsNotEmpty({
+    message: 'incapacityReason is required for an emergency consent',
+  })
+  @IsString()
+  incapacityReason?: string;
+
+  @ApiProperty({
+    required: false,
+    enum: [ShrFlag.No, ShrFlag.Yes],
+    description:
+      '0 when the patient cannot consent for themselves. Defaults to 1. Requires representativeCrId. Note the polarity is inverted on close-visit, where patientIncapable: 1 carries the same meaning.',
+  })
+  @IsOptional()
+  @IsIn([ShrFlag.No, ShrFlag.Yes])
+  patientCapable?: ShrFlag;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Client Registry identifier of the principal consenting on the patient's behalf. Routes the consent and its OTP to them.",
+  })
+  @ValidateIf(
+    (dto: RequestShrConsentDto) =>
+      dto.patientCapable === ShrFlag.No || dto.representativeCrId !== undefined,
+  )
+  @IsNotEmpty({
+    message: 'representativeCrId is required when patientCapable is 0',
+  })
+  @IsString()
+  representativeCrId?: string;
+
+  @ApiProperty({
+    required: false,
+    enum: ShrRepresentativeRelationship,
+    description:
+      'How the representative relates to the patient. Required whenever representativeCrId is provided.',
+  })
+  @ValidateIf(
+    (dto: RequestShrConsentDto) =>
+      dto.representativeCrId !== undefined ||
+      dto.representativeRelationship !== undefined,
+  )
+  @IsEnum(ShrRepresentativeRelationship, {
+    message:
+      'representativeRelationship is required whenever representativeCrId is provided',
+  })
+  representativeRelationship?: ShrRepresentativeRelationship;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Date the visit starts, as YYYY-MM-DD. Defaults to the date DHA creates the consent.',
+    example: '2026-07-18',
+  })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'startDate must be a YYYY-MM-DD date',
+  })
+  startDate?: string;
 
   @ApiProperty()
   @IsNotEmpty()

--- a/packages/hie-saf/src/shr/dto/shr-location-request.dto.ts
+++ b/packages/hie-saf/src/shr/dto/shr-location-request.dto.ts
@@ -3,8 +3,9 @@ import { IsNotEmpty, IsString } from 'class-validator';
 
 /**
  * Body/query for the SHR routes whose only client input is the location the
- * facility headers are resolved from — consent status, resend OTP, refresh
- * consent and close visit. Every other value is a path param.
+ * facility headers are resolved from — consent status, resend OTP and refresh
+ * consent. Every other value is a path param. Close visit takes an optional
+ * body beyond this, so it has its own `CloseShrVisitDto`.
  */
 export class ShrLocationRequestDto {
   @ApiProperty()

--- a/packages/hie-saf/src/shr/dto/verify-shr-consent.dto.ts
+++ b/packages/hie-saf/src/shr/dto/verify-shr-consent.dto.ts
@@ -1,24 +1,96 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
+import { ShrConsentDecision } from '../types';
 
 /**
- * Verify an SHR consent with the OTP the patient received. Returns the
- * `consent_token` used as `X-Consent-Token` when reading records.
+ * Verify an SHR consent with the OTP the patient received. Also the call that
+ * records a *refusal*, and the one that completes an OTP-gated visit closure —
+ * DHA tells those apart server side from the `otpRecord`, so there is no branch
+ * here. The three outcomes differ only in the response.
+ *
+ * On an approval it returns the `consent_token` used as `X-Consent-Token` when
+ * reading records. A refusal is the one path that carries no `otp` — the
+ * patient never gave one — so `otp` is required only when not rejecting.
+ *
  * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
  */
 export class VerifyShrConsentDto {
-  @ApiProperty({ description: 'OTP the patient received' })
-  @IsNotEmpty()
+  /**
+   * Required on every path except a recorded refusal: a patient who declines
+   * never hands over a password, so `consentDecision: 'Reject'` is the one case
+   * that goes up without an `otp`.
+   */
+  @ApiProperty({
+    required: false,
+    description:
+      'OTP the patient received. Required unless consentDecision is Reject.',
+  })
+  @ValidateIf(
+    (dto: VerifyShrConsentDto) =>
+      dto.consentDecision !== ShrConsentDecision.Reject,
+  )
+  @IsNotEmpty({
+    message: 'otp is required unless the consent is being rejected',
+  })
   @IsString()
-  otp!: string;
+  otp?: string;
 
   @ApiProperty({
     description:
-      'OTP record reference from the consent request (or from the latest resend-otp call)',
+      'OTP record reference from the consent request, the latest resend-otp call, or the close-visit call being completed',
   })
   @IsNotEmpty()
   @IsString()
   otpRecord!: string;
+
+  @ApiProperty({
+    required: false,
+    enum: ShrConsentDecision,
+    description:
+      "The patient's decision. Treated as an approval by DHA when omitted.",
+  })
+  @IsOptional()
+  @IsEnum(ShrConsentDecision)
+  consentDecision?: ShrConsentDecision;
+
+  @ApiProperty({
+    required: false,
+    description: 'Why the patient refused. Required on a Reject decision.',
+    example: 'Patient denied consent',
+  })
+  @ValidateIf(
+    (dto: VerifyShrConsentDto) =>
+      dto.consentDecision === ShrConsentDecision.Reject ||
+      dto.rejectionReason !== undefined,
+  )
+  @IsNotEmpty({
+    message: 'rejectionReason is required when rejecting a consent',
+  })
+  @IsString()
+  rejectionReason?: string;
+
+  /**
+   * Only used locally, never forwarded: an approval issues the token this
+   * middleware records against `(crId, locationUuid)`. Optional so existing
+   * callers keep working — when it is absent the CR id is recovered from the
+   * issued token's `sub` claim, and if that is missing too the consent still
+   * succeeds, it just is not tracked for `GET /shr/consents/active`.
+   */
+  @ApiProperty({
+    required: false,
+    description:
+      'Client Registry identifier of the patient. Not sent to DHA — it keys the consent session recorded on approval.',
+  })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  crId?: string;
 
   @ApiProperty()
   @IsNotEmpty()

--- a/packages/hie-saf/src/shr/shr-consent-session.store.spec.ts
+++ b/packages/hie-saf/src/shr/shr-consent-session.store.spec.ts
@@ -1,0 +1,167 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ShrConsentSession } from '../core/database/entities/shr-consent-session.entity';
+import { ShrConsentSessionStore } from './shr-consent-session.store';
+import { ShrConsentSessionStatus } from './types';
+
+const tokenWith = (claims: Record<string, unknown>) =>
+  [
+    Buffer.from(JSON.stringify({ alg: 'ES256', typ: 'JWT' })).toString(
+      'base64url',
+    ),
+    Buffer.from(JSON.stringify(claims)).toString('base64url'),
+    'signature',
+  ].join('.');
+
+describe('ShrConsentSessionStore', () => {
+  let store: ShrConsentSessionStore;
+  const repository = {
+    findOne: jest.fn(),
+    findOneBy: jest.fn(),
+    create: jest.fn(),
+    merge: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    // Stand in for TypeORM's own merge/create.
+    repository.create.mockImplementation(() => ({}));
+    repository.merge.mockImplementation((target, patch) =>
+      Object.assign(target, patch),
+    );
+    repository.save.mockImplementation((entity) => Promise.resolve(entity));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShrConsentSessionStore,
+        {
+          provide: getRepositoryToken(ShrConsentSession),
+          useValue: repository,
+        },
+      ],
+    }).compile();
+
+    store = module.get(ShrConsentSessionStore);
+  });
+
+  it('looks an open session up by the (crId, locationUuid) pair', async () => {
+    repository.findOne.mockResolvedValue(null);
+
+    await store.findOpenSession('CR-1', 'loc-1');
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: {
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+        status: ShrConsentSessionStatus.Open,
+      },
+      order: { id: 'DESC' },
+    });
+  });
+
+  it("stores the token's own exp claim rather than a locally invented expiry", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    repository.findOneBy.mockResolvedValue(null);
+
+    const saved = await store.recordIssuedToken({
+      crId: 'CR-1',
+      locationUuid: 'loc-1',
+      visitId: 'v-1',
+      consentToken: tokenWith({ exp }),
+      consentId: 'c-1',
+    });
+
+    expect(saved).toMatchObject({
+      crId: 'CR-1',
+      locationUuid: 'loc-1',
+      visitId: 'v-1',
+      consentId: 'c-1',
+      status: ShrConsentSessionStatus.Open,
+    });
+    expect(saved?.tokenExpiresAt?.getTime()).toBe(exp * 1000);
+  });
+
+  it('leaves the expiry unknown when the token carries no exp claim', async () => {
+    repository.findOneBy.mockResolvedValue(null);
+
+    const saved = await store.recordIssuedToken({
+      crId: 'CR-1',
+      locationUuid: 'loc-1',
+      visitId: 'v-1',
+      consentToken: tokenWith({ sub: 'CR-1' }),
+    });
+
+    expect(saved?.tokenExpiresAt).toBeNull();
+    expect(saved?.consentId).toBeNull();
+  });
+
+  it('updates the row for a visit it already tracks instead of inserting a second one', async () => {
+    const existing = {
+      id: 7,
+      visitId: 'v-1',
+      consentId: 'c-1',
+      status: ShrConsentSessionStatus.Closed,
+    };
+    repository.findOneBy.mockResolvedValue(existing);
+
+    const saved = await store.recordIssuedToken({
+      crId: 'CR-1',
+      locationUuid: 'loc-1',
+      visitId: 'v-1',
+      consentToken: 'tok-2',
+    });
+
+    expect(repository.create).not.toHaveBeenCalled();
+    expect(saved).toMatchObject({
+      id: 7,
+      // Kept from the existing row, since open-visits does not carry it.
+      consentId: 'c-1',
+      status: ShrConsentSessionStatus.Open,
+    });
+  });
+
+  it('does nothing when refreshing a visit it does not track', async () => {
+    repository.findOneBy.mockResolvedValue(null);
+
+    expect(await store.recordRefreshedToken('v-unknown', 'tok-2')).toBeNull();
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  it('never lets a bookkeeping failure surface to the caller', async () => {
+    repository.findOneBy.mockResolvedValue(null);
+    repository.save.mockRejectedValue(new Error('deadlock'));
+
+    // The DHA call already succeeded by this point — a failed write here must
+    // not turn a granted consent into an error.
+    expect(
+      await store.recordIssuedToken({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+        visitId: 'v-1',
+        consentToken: 'tok-1',
+      }),
+    ).toBeNull();
+
+    repository.update.mockRejectedValue(new Error('deadlock'));
+    await expect(store.markClosedByVisit('v-1')).resolves.toBeUndefined();
+    await expect(store.markClosedByConsent('c-1')).resolves.toBeUndefined();
+  });
+
+  it('closes by visit and by consent', async () => {
+    repository.update.mockResolvedValue({ affected: 1 });
+
+    await store.markClosedByVisit('v-1');
+    expect(repository.update).toHaveBeenCalledWith(
+      { visitId: 'v-1' },
+      { status: ShrConsentSessionStatus.Closed },
+    );
+
+    await store.markClosedByConsent('c-1');
+    expect(repository.update).toHaveBeenCalledWith(
+      { consentId: 'c-1' },
+      { status: ShrConsentSessionStatus.Closed },
+    );
+  });
+});

--- a/packages/hie-saf/src/shr/shr-consent-session.store.ts
+++ b/packages/hie-saf/src/shr/shr-consent-session.store.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ShrConsentSession } from '../core/database/entities/shr-consent-session.entity';
+import { ShrConsentSessionStatus } from './types';
+import { consentTokenExpiry } from './utils/consent-token.helper';
+
+/** What a caller has to supply to record a newly issued consent token. */
+export type RecordedConsentSession = {
+  crId: string;
+  locationUuid: string;
+  visitId: string;
+  consentToken: string;
+  /** Unknown when the session was reconstructed from `GET /shr/open-visits`. */
+  consentId?: string | null;
+};
+
+/**
+ * Server side record of which `(crId, locationUuid)` pairs currently hold an
+ * open, usable SHR consent — see `ShrConsentSession`.
+ *
+ * Every method here is *bookkeeping*: a DHA call has already succeeded by the
+ * time it runs, so a failure to write must never turn a successful consent into
+ * an error for the caller. Writes are therefore best effort and log instead of
+ * throwing. Reads are the exception — `findOpenSession` is load bearing for
+ * `GET /shr/consents/active` and lets its errors surface.
+ */
+@Injectable()
+export class ShrConsentSessionStore {
+  constructor(
+    @InjectRepository(ShrConsentSession)
+    private readonly sessionRepository: Repository<ShrConsentSession>,
+  ) {}
+
+  /** The open session for a patient at a facility, if there is one. */
+  async findOpenSession(
+    crId: string,
+    locationUuid: string,
+  ): Promise<ShrConsentSession | null> {
+    return this.sessionRepository.findOne({
+      where: { crId, locationUuid, status: ShrConsentSessionStatus.Open },
+      order: { id: 'DESC' },
+    });
+  }
+
+  /**
+   * Records a token DHA has just issued — an OTP approval, or an emergency
+   * consent approved on the spot. Re-issuing for a visit we already track
+   * updates that row rather than inserting a second one, since `visit_id` is
+   * unique.
+   */
+  async recordIssuedToken(
+    session: RecordedConsentSession,
+  ): Promise<ShrConsentSession | null> {
+    try {
+      const existing = await this.sessionRepository.findOneBy({
+        visitId: session.visitId,
+      });
+      const issuedAt = new Date();
+      const entity = this.sessionRepository.merge(
+        existing ?? this.sessionRepository.create(),
+        {
+          crId: session.crId,
+          locationUuid: session.locationUuid,
+          consentId: session.consentId ?? existing?.consentId ?? null,
+          visitId: session.visitId,
+          consentToken: session.consentToken,
+          status: ShrConsentSessionStatus.Open,
+          tokenIssuedAt: issuedAt,
+          tokenExpiresAt: consentTokenExpiry(session.consentToken),
+        },
+      );
+      return await this.sessionRepository.save(entity);
+    } catch (error) {
+      Logger.error(
+        `Could not record the SHR consent session for visit ${session.visitId}: ${(error as Error)?.message ?? error}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Stores a token that came back from `POST /shr/visits/{visit_id}/refresh`.
+   * A visit we never recorded is not an error — the consent may have been
+   * granted before this table existed, or by another instance — there is just
+   * nothing to update.
+   */
+  async recordRefreshedToken(
+    visitId: string,
+    consentToken: string,
+  ): Promise<ShrConsentSession | null> {
+    try {
+      const existing = await this.sessionRepository.findOneBy({ visitId });
+      if (!existing) {
+        return null;
+      }
+      existing.consentToken = consentToken;
+      existing.tokenIssuedAt = new Date();
+      existing.tokenExpiresAt = consentTokenExpiry(consentToken);
+      existing.status = ShrConsentSessionStatus.Open;
+      return await this.sessionRepository.save(existing);
+    } catch (error) {
+      Logger.error(
+        `Could not update the SHR consent session for visit ${visitId}: ${(error as Error)?.message ?? error}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Closes the local record. Only call this once a closure has actually
+   * completed — DHA returning `end_date`, from either `closeVisit` (immediate
+   * closure) or `verifyConsent` (OTP-gated closure completed). An OTP-gated
+   * `closeVisit` returns `otp_record` and leaves the visit open, so it must not
+   * land here.
+   */
+  async markClosedByVisit(visitId: string): Promise<void> {
+    try {
+      await this.sessionRepository.update(
+        { visitId },
+        { status: ShrConsentSessionStatus.Closed },
+      );
+    } catch (error) {
+      Logger.error(
+        `Could not close the SHR consent session for visit ${visitId}: ${(error as Error)?.message ?? error}`,
+      );
+    }
+  }
+
+  /**
+   * Same, for a closure completed through `verifyConsent`, where the response
+   * may identify the consent rather than the visit.
+   */
+  async markClosedByConsent(consentId: string): Promise<void> {
+    try {
+      await this.sessionRepository.update(
+        { consentId },
+        { status: ShrConsentSessionStatus.Closed },
+      );
+    } catch (error) {
+      Logger.error(
+        `Could not close the SHR consent session for consent ${consentId}: ${(error as Error)?.message ?? error}`,
+      );
+    }
+  }
+}

--- a/packages/hie-saf/src/shr/shr.controller.ts
+++ b/packages/hie-saf/src/shr/shr.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Get,
   Headers,
+  Logger,
   Param,
   Post,
   Query,
@@ -13,8 +14,11 @@ import {
 import { ApiHeader } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { OpenMrsAuthGuard } from '../auth/guards/openmrs-auth-guard/openmrs-auth.guard';
+import { CloseShrVisitDto } from './dto/close-shr-visit.dto';
 import { FetchPatientRecordsDto } from './dto/fetch-patient-records.dto';
 import { FetchResourceLabelsDto } from './dto/fetch-resource-labels.dto';
+import { GetActiveConsentDto } from './dto/get-active-consent.dto';
+import { ListOpenVisitsDto } from './dto/list-open-visits.dto';
 import { RequestShrConsentDto } from './dto/request-shr-consent.dto';
 import { ShrLocationRequestDto } from './dto/shr-location-request.dto';
 import {
@@ -28,9 +32,10 @@ import { CONSENT_TOKEN_HEADER, ShrService } from './shr.service';
 import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
 
 /**
- * Shared Health Record read/write path. Consent tokens are handed back to
- * the caller and passed in again on reads and writes — nothing is held
- * server side.
+ * Shared Health Record read/write path. Consent tokens are handed back to the
+ * caller and passed in again on reads and writes; they are additionally
+ * recorded server side per `(crId, locationUuid)`, which is what
+ * `GET /shr/consents/active` answers from.
  */
 @UseGuards(OpenMrsAuthGuard)
 @Controller('shr')
@@ -41,8 +46,15 @@ export class ShrController {
   ) {}
 
   @Post('consents')
-  requestConsent(@Body() body: RequestShrConsentDto) {
-    return this.shrService.requestConsent(body);
+  async requestConsent(
+    @Body() body: RequestShrConsentDto,
+    @Req() request: Request,
+  ) {
+    const practitionerId = await this.resolvePractitionerIdBestEffort(
+      request,
+      body.locationUuid,
+    );
+    return this.shrService.requestConsent(body, practitionerId);
   }
 
   @Post('consents/:consentId/verify')
@@ -51,6 +63,17 @@ export class ShrController {
     @Body() body: VerifyShrConsentDto,
   ) {
     return this.shrService.verifyConsent(params.consentId, body);
+  }
+
+  /**
+   * A usable consent token for a patient at this facility, from the recorded
+   * session or — failing that — from DHA's open visits plus a refresh.
+   * Declared before `consents/:consentId/status` only for readability; the two
+   * paths have different segment counts and cannot collide.
+   */
+  @Get('consents/active')
+  getActiveConsent(@Query() query: GetActiveConsentDto) {
+    return this.shrService.getActiveConsent(query);
   }
 
   @Get('consents/:consentId/status')
@@ -126,6 +149,12 @@ export class ShrController {
     );
   }
 
+  /** Open consent visits for a patient at this facility — visit ids only. */
+  @Get('open-visits')
+  listOpenVisits(@Query() query: ListOpenVisitsDto) {
+    return this.shrService.listOpenVisits(query);
+  }
+
   @Post('visits/:visitId/refresh')
   @ApiHeader({
     name: CONSENT_TOKEN_HEADER,
@@ -148,9 +177,9 @@ export class ShrController {
   @Post('visits/:visitId/close')
   closeVisit(
     @Param() params: ShrVisitParamsDto,
-    @Body() body: ShrLocationRequestDto,
+    @Body() body: CloseShrVisitDto,
   ) {
-    return this.shrService.closeVisit(params.visitId, body.locationUuid);
+    return this.shrService.closeVisit(params.visitId, body.locationUuid, body);
   }
 
   @Get('resource-labels')
@@ -159,5 +188,29 @@ export class ShrController {
       throw new BadRequestException('Provide resourceName and/or code');
     }
     return this.shrService.fetchResourceLabels(query);
+  }
+
+  /**
+   * DHA accepts a consent request without `practitioner_id`, and the resolver
+   * throws when the provider is not yet in `hwr_sync`. Sending it is right —
+   * the Consent Management Platform expects it, and a practitioner identity
+   * must never come from the client — but not at the cost of blocking a consent
+   * that would otherwise succeed.
+   */
+  private async resolvePractitionerIdBestEffort(
+    request: Request,
+    locationUuid: string,
+  ): Promise<string | undefined> {
+    try {
+      return await this.practitionerResolver.resolveLoggedInPractitionerId(
+        request.cookies?.['JSESSIONID'] as string | undefined,
+        locationUuid,
+      );
+    } catch (error) {
+      Logger.warn(
+        `Requesting SHR consent without practitioner_id — could not resolve the logged in practitioner: ${(error as Error)?.message ?? error}`,
+      );
+      return undefined;
+    }
   }
 }

--- a/packages/hie-saf/src/shr/shr.module.ts
+++ b/packages/hie-saf/src/shr/shr.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FacilityLocation } from '../core/database/entities/facility-locations.entity';
 import { HwrSync } from '../core/database/entities/hwr_sync.entity';
+import { ShrConsentSession } from '../core/database/entities/shr-consent-session.entity';
 import { HealthWorkerRegistryModule } from '../health-worker-registry/health-worker-registry.module';
 import { HealthWorkerRegistryService } from '../health-worker-registry/health-worker-registry.service';
 import { HieHttpRequestModule } from '../hie-http-request/hie-http-request.module';
 import { LocationFacilityHelper } from '../shared/utils/location-facility.helper';
+import { ShrConsentSessionStore } from './shr-consent-session.store';
 import { ShrController } from './shr.controller';
 import { ShrService } from './shr.service';
 import { PractitionerResolver } from '../shared/utils/practitioner-resolver.helper';
@@ -14,11 +16,12 @@ import { PractitionerResolver } from '../shared/utils/practitioner-resolver.help
   imports: [
     HieHttpRequestModule,
     HealthWorkerRegistryModule,
-    TypeOrmModule.forFeature([FacilityLocation, HwrSync]),
+    TypeOrmModule.forFeature([FacilityLocation, HwrSync, ShrConsentSession]),
   ],
   controllers: [ShrController],
   providers: [
     ShrService,
+    ShrConsentSessionStore,
     LocationFacilityHelper,
     PractitionerResolver,
     HealthWorkerRegistryService,

--- a/packages/hie-saf/src/shr/shr.service.spec.ts
+++ b/packages/hie-saf/src/shr/shr.service.spec.ts
@@ -3,8 +3,15 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HieHttpRequests } from '../hie-http-request/hie-http-requests';
 import { LocationFacilityHelper } from '../shared/utils/location-facility.helper';
+import { ShrConsentSessionStore } from './shr-consent-session.store';
 import { CONSENT_TOKEN_HEADER, ShrService } from './shr.service';
-import { ShrVisitType } from './types';
+import {
+  ShrActiveConsentSource,
+  ShrConsentDecision,
+  ShrFlag,
+  ShrRepresentativeRelationship,
+  ShrVisitType,
+} from './types';
 
 const BASE_URL = 'https://ilm-dev.dha.go.ke/uat-middleware/api/v1';
 
@@ -14,6 +21,18 @@ const upstreamResponse = (body: unknown, ok = true, status = 200) => ({
   text: () => Promise.resolve(JSON.stringify(body)),
 });
 
+/** Unsigned stand-in for a DHA consent token, so `exp`/`sub` can be steered. */
+const tokenWith = (claims: Record<string, unknown>) =>
+  [
+    Buffer.from(JSON.stringify({ alg: 'ES256', typ: 'JWT' })).toString(
+      'base64url',
+    ),
+    Buffer.from(JSON.stringify(claims)).toString('base64url'),
+    'signature',
+  ].join('.');
+
+const inOneHour = () => Math.floor(Date.now() / 1000) + 3600;
+
 describe('ShrService', () => {
   let service: ShrService;
   const hieHttpRequests = {
@@ -22,6 +41,13 @@ describe('ShrService', () => {
   };
   const configService = { get: jest.fn() };
   const locationFacilityHelper = { getFacilityUsingLocationUuid: jest.fn() };
+  const consentSessionStore = {
+    findOpenSession: jest.fn(),
+    recordIssuedToken: jest.fn(),
+    recordRefreshedToken: jest.fn(),
+    markClosedByVisit: jest.fn(),
+    markClosedByConsent: jest.fn(),
+  };
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -33,6 +59,7 @@ describe('ShrService', () => {
         { provide: HieHttpRequests, useValue: hieHttpRequests },
         { provide: ConfigService, useValue: configService },
         { provide: LocationFacilityHelper, useValue: locationFacilityHelper },
+        { provide: ShrConsentSessionStore, useValue: consentSessionStore },
       ],
     }).compile();
 
@@ -43,69 +70,461 @@ describe('ShrService', () => {
     expect(service).toBeDefined();
   });
 
-  it('resolves facility_id from the location when requesting consent', async () => {
-    locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
-      frCode: 'FID-123',
-    });
-    hieHttpRequests.sendPostRequest.mockResolvedValue(
-      upstreamResponse({ consent_id: 'c-1', otp_record: 'otp-1' }),
-    );
+  describe('requestConsent', () => {
+    it('resolves facility_id from the location and sends only the fields it was given', async () => {
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_id: 'c-1', otp_record: 'otp-1' }),
+      );
 
-    const result = await service.requestConsent({
-      crId: 'CR-1',
-      requestedBy: 'Dr Test',
-      visitType: ShrVisitType.OutPatient,
-      locationUuid: 'loc-1',
-    });
+      const result = await service.requestConsent({
+        crId: 'CR-1',
+        requestedBy: 'Dr Test',
+        visitType: ShrVisitType.OutPatient,
+        locationUuid: 'loc-1',
+      });
 
-    expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
-      `${BASE_URL}/shr/consents`,
-      {
-        cr_id: 'CR-1',
-        facility_id: 'FID-123',
-        requested_by: 'Dr Test',
-        visit_type: 'OP',
-      },
-      'loc-1',
-      undefined,
-    );
-    expect(result.consent_id).toBe('c-1');
-  });
-
-  it('rejects a consent request when the location has no facility code', async () => {
-    locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
-      frCode: null,
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/consents`,
+        {
+          cr_id: 'CR-1',
+          facility_id: 'FID-123',
+          requested_by: 'Dr Test',
+          visit_type: 'OP',
+        },
+        'loc-1',
+        undefined,
+      );
+      expect(result.consent_id).toBe('c-1');
+      // Standard request: no token yet, so nothing to record.
+      expect(consentSessionStore.recordIssuedToken).not.toHaveBeenCalled();
     });
 
-    await expect(
-      service.requestConsent({
+    it('forwards the resolved practitioner id when the caller supplies one', async () => {
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_id: 'c-1', otp_record: 'otp-1' }),
+      );
+
+      await service.requestConsent(
+        {
+          crId: 'CR-1',
+          requestedBy: 'Dr Test',
+          visitType: ShrVisitType.InPatient,
+          locationUuid: 'loc-1',
+        },
+        'PUID-0000443-3',
+      );
+
+      expect(hieHttpRequests.sendPostRequest.mock.calls[0][1]).toMatchObject({
+        practitioner_id: 'PUID-0000443-3',
+      });
+    });
+
+    it('maps the dependant fields to the documented snake_case payload', async () => {
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_id: 'c-1', otp_record: 'otp-1' }),
+      );
+
+      await service.requestConsent({
+        crId: 'CR-1',
+        requestedBy: 'Registration Clerk',
+        visitType: ShrVisitType.OutPatient,
+        emergency: ShrFlag.No,
+        patientCapable: ShrFlag.No,
+        incapacityReason: 'Incapacitated adult',
+        representativeCrId: 'CR-2',
+        representativeRelationship:
+          ShrRepresentativeRelationship.HealthcareProxy,
+        startDate: '2026-07-18',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/consents`,
+        {
+          cr_id: 'CR-1',
+          facility_id: 'FID-123',
+          requested_by: 'Registration Clerk',
+          visit_type: 'OP',
+          emergency: 0,
+          patient_capable: 0,
+          incapacity_reason: 'Incapacitated adult',
+          representative_cr_id: 'CR-2',
+          representative_relationship: 'Healthcare Proxy',
+          start_date: '2026-07-18',
+        },
+        'loc-1',
+        undefined,
+      );
+    });
+
+    it('records the consent session for an emergency consent, which never reaches verify', async () => {
+      const consentToken = tokenWith({ exp: inOneHour(), sub: 'CR-1' });
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({
+          consent_id: 'c-1',
+          consent_status: 'Approved',
+          consent_token: consentToken,
+          emergency: true,
+          visit_id: 'v-1',
+        }),
+      );
+
+      const result = await service.requestConsent({
         crId: 'CR-1',
         requestedBy: 'Dr Test',
         visitType: ShrVisitType.InPatient,
+        emergency: ShrFlag.Yes,
+        incapacityReason: 'Unconscious on arrival',
         locationUuid: 'loc-1',
-      }),
-    ).rejects.toThrow(HttpException);
-    expect(hieHttpRequests.sendPostRequest).not.toHaveBeenCalled();
-  });
+      });
 
-  it('maps the otp record to snake_case when verifying consent', async () => {
-    hieHttpRequests.sendPostRequest.mockResolvedValue(
-      upstreamResponse({ consent_token: 'tok-1', visit_id: 'v-1' }),
-    );
-
-    const result = await service.verifyConsent('c-1', {
-      otp: '123456',
-      otpRecord: 'otp-1',
-      locationUuid: 'loc-1',
+      expect(hieHttpRequests.sendPostRequest.mock.calls[0][1]).toMatchObject({
+        emergency: 1,
+        incapacity_reason: 'Unconscious on arrival',
+      });
+      expect(consentSessionStore.recordIssuedToken).toHaveBeenCalledWith({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+        visitId: 'v-1',
+        consentToken,
+        consentId: 'c-1',
+      });
+      // The emergency shape has to stay distinguishable from the OTP shape.
+      expect(result.consent_token).toBe(consentToken);
+      expect(result.otp_record).toBeUndefined();
     });
 
-    expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
-      `${BASE_URL}/shr/consents/c-1/verify`,
-      { otp: '123456', otp_record: 'otp-1' },
-      'loc-1',
-      undefined,
-    );
-    expect(result).toEqual({ consent_token: 'tok-1', visit_id: 'v-1' });
+    it('rejects a consent request when the location has no facility code', async () => {
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: null,
+      });
+
+      await expect(
+        service.requestConsent({
+          crId: 'CR-1',
+          requestedBy: 'Dr Test',
+          visitType: ShrVisitType.InPatient,
+          locationUuid: 'loc-1',
+        }),
+      ).rejects.toThrow(HttpException);
+      expect(hieHttpRequests.sendPostRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyConsent', () => {
+    it('maps the otp record to snake_case and records the session on approval', async () => {
+      const consentToken = tokenWith({ exp: inOneHour(), sub: 'CR-1' });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_token: consentToken, visit_id: 'v-1' }),
+      );
+
+      const result = await service.verifyConsent('c-1', {
+        otp: '123456',
+        otpRecord: 'otp-1',
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/consents/c-1/verify`,
+        { otp: '123456', otp_record: 'otp-1' },
+        'loc-1',
+        undefined,
+      );
+      expect(consentSessionStore.recordIssuedToken).toHaveBeenCalledWith({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+        visitId: 'v-1',
+        consentToken,
+        consentId: 'c-1',
+      });
+      expect(result).toEqual({ consent_token: consentToken, visit_id: 'v-1' });
+    });
+
+    it("falls back to the token's sub claim when the caller sent no crId", async () => {
+      const consentToken = tokenWith({ sub: 'CR0824441219329-5' });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_token: consentToken, visit_id: 'v-1' }),
+      );
+
+      await service.verifyConsent('c-1', {
+        otp: '123456',
+        otpRecord: 'otp-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(consentSessionStore.recordIssuedToken).toHaveBeenCalledWith(
+        expect.objectContaining({ crId: 'CR0824441219329-5' }),
+      );
+    });
+
+    it('still returns the approval when there is no crId to record it against', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_token: 'opaque-token', visit_id: 'v-1' }),
+      );
+
+      const result = await service.verifyConsent('c-1', {
+        otp: '123456',
+        otpRecord: 'otp-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(consentSessionStore.recordIssuedToken).not.toHaveBeenCalled();
+      expect(result.consent_token).toBe('opaque-token');
+    });
+
+    it('forwards a rejection with no otp, and records no session since no token is issued', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({
+          consent_id: 'c-1',
+          consent_status: 'Rejected',
+          message: 'Consent has been rejected',
+        }),
+      );
+
+      const result = await service.verifyConsent('c-1', {
+        otpRecord: 'otp-1',
+        consentDecision: ShrConsentDecision.Reject,
+        rejectionReason: 'Patient denied consent',
+        locationUuid: 'loc-1',
+      });
+
+      // A patient who declines never hands over a password, so `otp` must not
+      // be invented to satisfy the shape.
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/consents/c-1/verify`,
+        {
+          otp_record: 'otp-1',
+          consent_decision: 'Reject',
+          rejection_reason: 'Patient denied consent',
+        },
+        'loc-1',
+        undefined,
+      );
+      expect(consentSessionStore.recordIssuedToken).not.toHaveBeenCalled();
+      expect(result.consent_status).toBe('Rejected');
+    });
+
+    it('closes the local session when the verification completed an OTP-gated closure', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({
+          consent_id: 'c-1',
+          end_date: '2026-07-15',
+          visit_id: 'v-1',
+        }),
+      );
+
+      await service.verifyConsent('c-1', {
+        otp: '123456',
+        otpRecord: 'closure-otp-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(consentSessionStore.markClosedByVisit).toHaveBeenCalledWith('v-1');
+    });
+  });
+
+  describe('closeVisit', () => {
+    it('sends an empty body and does not close the local session on an OTP-gated closure', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({
+          consent_id: 'c-1',
+          otp_record: '9fh38gd21k',
+          visit_id: 'v-1',
+        }),
+      );
+
+      await service.closeVisit('v-1', 'loc-1', { locationUuid: 'loc-1' });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/visits/v-1/close`,
+        {},
+        'loc-1',
+        undefined,
+      );
+      // The visit stays open until that password is verified.
+      expect(consentSessionStore.markClosedByVisit).not.toHaveBeenCalled();
+    });
+
+    it('forwards patient_incapable and closes the local session on an immediate closure', async () => {
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({
+          consent_id: 'c-1',
+          end_date: '2026-07-15',
+          visit_id: 'v-1',
+        }),
+      );
+
+      await service.closeVisit('v-1', 'loc-1', {
+        patientIncapable: ShrFlag.Yes,
+        incapacityReason: 'Unconscious',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/visits/v-1/close`,
+        { patient_incapable: 1, incapacity_reason: 'Unconscious' },
+        'loc-1',
+        undefined,
+      );
+      expect(consentSessionStore.markClosedByVisit).toHaveBeenCalledWith('v-1');
+    });
+  });
+
+  describe('listOpenVisits', () => {
+    it('sends the CR id as patient_id and the resolved facility code', async () => {
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse({ visits: [{ visit_id: 'v-1' }] }),
+      );
+
+      const result = await service.listOpenVisits({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendGetRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/open-visits?patient_id=CR-1&facility_id=FID-123`,
+        'loc-1',
+        undefined,
+      );
+      expect(result.visits).toEqual([{ visit_id: 'v-1' }]);
+    });
+  });
+
+  describe('getActiveConsent', () => {
+    it('hands back the local token when it says it is still valid', async () => {
+      const expiresAt = new Date(Date.now() + 3_600_000);
+      consentSessionStore.findOpenSession.mockResolvedValue({
+        visitId: 'v-1',
+        consentId: 'c-1',
+        consentToken: 'tok-1',
+        tokenExpiresAt: expiresAt,
+      });
+
+      const result = await service.getActiveConsent({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(result).toEqual({
+        hasActiveConsent: true,
+        message: 'Active consent found',
+        source: ShrActiveConsentSource.Local,
+        visitId: 'v-1',
+        consentId: 'c-1',
+        consentToken: 'tok-1',
+        tokenExpiresAt: expiresAt.toISOString(),
+      });
+      expect(hieHttpRequests.sendPostRequest).not.toHaveBeenCalled();
+      expect(hieHttpRequests.sendGetRequest).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the local session when its token cannot be shown to be valid', async () => {
+      // No exp claim, so staleness is unknowable — refresh rather than guess.
+      consentSessionStore.findOpenSession.mockResolvedValue({
+        visitId: 'v-1',
+        consentId: 'c-1',
+        consentToken: 'tok-1',
+        tokenExpiresAt: null,
+      });
+      hieHttpRequests.sendPostRequest.mockResolvedValue(
+        upstreamResponse({ consent_token: 'tok-2' }),
+      );
+
+      const result = await service.getActiveConsent({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(hieHttpRequests.sendPostRequest).toHaveBeenCalledWith(
+        `${BASE_URL}/shr/visits/v-1/refresh`,
+        {},
+        'loc-1',
+        { [CONSENT_TOKEN_HEADER]: 'tok-1' },
+      );
+      expect(result).toMatchObject({
+        hasActiveConsent: true,
+        source: ShrActiveConsentSource.Refreshed,
+        visitId: 'v-1',
+        consentToken: 'tok-2',
+      });
+    });
+
+    it('closes a local session DHA will no longer refresh and falls back to open visits', async () => {
+      consentSessionStore.findOpenSession.mockResolvedValue({
+        visitId: 'v-stale',
+        consentId: 'c-1',
+        consentToken: 'tok-1',
+        tokenExpiresAt: null,
+      });
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendPostRequest
+        .mockResolvedValueOnce(
+          upstreamResponse({ message: 'visit is closed' }, false, 400),
+        )
+        .mockResolvedValueOnce(upstreamResponse({ consent_token: 'tok-3' }));
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse({ visits: [{ visit_id: 'v-2' }] }),
+      );
+
+      const result = await service.getActiveConsent({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(consentSessionStore.markClosedByVisit).toHaveBeenCalledWith(
+        'v-stale',
+      );
+      // Reconstructed from open-visits, which carries no consent id.
+      expect(consentSessionStore.recordIssuedToken).toHaveBeenCalledWith({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+        visitId: 'v-2',
+        consentToken: 'tok-3',
+      });
+      expect(result).toMatchObject({
+        hasActiveConsent: true,
+        source: ShrActiveConsentSource.OpenVisits,
+        visitId: 'v-2',
+        consentId: null,
+        consentToken: 'tok-3',
+      });
+    });
+
+    it('reports no active consent when DHA lists no open visit', async () => {
+      consentSessionStore.findOpenSession.mockResolvedValue(null);
+      locationFacilityHelper.getFacilityUsingLocationUuid.mockResolvedValue({
+        frCode: 'FID-123',
+      });
+      hieHttpRequests.sendGetRequest.mockResolvedValue(
+        upstreamResponse({ visits: [] }),
+      );
+
+      const result = await service.getActiveConsent({
+        crId: 'CR-1',
+        locationUuid: 'loc-1',
+      });
+
+      expect(result.hasActiveConsent).toBe(false);
+      expect(result.consentToken).toBeUndefined();
+    });
   });
 
   it('sends the consent token header and returns the bundle unchanged', async () => {
@@ -148,7 +567,7 @@ describe('ShrService', () => {
     });
   });
 
-  it('forwards the current token when refreshing an open visit', async () => {
+  it('forwards the current token when refreshing an open visit and stores the new one', async () => {
     hieHttpRequests.sendPostRequest.mockResolvedValue(
       upstreamResponse({ consent_token: 'tok-2' }),
     );
@@ -160,6 +579,10 @@ describe('ShrService', () => {
       {},
       'loc-1',
       { [CONSENT_TOKEN_HEADER]: 'tok-1' },
+    );
+    expect(consentSessionStore.recordRefreshedToken).toHaveBeenCalledWith(
+      'v-1',
+      'tok-2',
     );
   });
 

--- a/packages/hie-saf/src/shr/shr.service.ts
+++ b/packages/hie-saf/src/shr/shr.service.ts
@@ -2,15 +2,23 @@ import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HieHttpRequests } from '../hie-http-request/hie-http-requests';
 import { LocationFacilityHelper } from '../shared/utils/location-facility.helper';
+import { CloseShrVisitDto } from './dto/close-shr-visit.dto';
 import { FetchPatientRecordsDto } from './dto/fetch-patient-records.dto';
 import { FetchResourceLabelsDto } from './dto/fetch-resource-labels.dto';
+import { GetActiveConsentDto } from './dto/get-active-consent.dto';
+import { ListOpenVisitsDto } from './dto/list-open-visits.dto';
 import { RequestShrConsentDto } from './dto/request-shr-consent.dto';
 import { SubmitShrBundleDto } from './dto/submit-shr-bundle.dto';
 import { VerifyShrConsentDto } from './dto/verify-shr-consent.dto';
+import { ShrConsentSessionStore } from './shr-consent-session.store';
 import {
+  ShrActiveConsentResponse,
+  ShrActiveConsentSource,
   ShrCloseVisitApiResponse,
+  ShrCloseVisitPayload,
   ShrConsentRequestPayload,
   ShrConsentStatusApiResponse,
+  ShrOpenVisitsApiResponse,
   ShrPassthroughResponse,
   ShrRefreshConsentApiResponse,
   ShrRequestConsentApiResponse,
@@ -19,6 +27,11 @@ import {
   ShrVerifyConsentApiResponse,
   ShrVerifyConsentPayload,
 } from './types';
+import {
+  consentTokenExpiry,
+  consentTokenSubject,
+  isConsentTokenUsable,
+} from './utils/consent-token.helper';
 
 /** Per visit consent token header required when reading records. */
 export const CONSENT_TOKEN_HEADER = 'X-Consent-Token';
@@ -26,8 +39,14 @@ export const CONSENT_TOKEN_HEADER = 'X-Consent-Token';
 /**
  * DHA Shared Health Record middleware. Runs on its own host
  * (`HIE_SHR_BASE_URL`), not the tiberbu `HIE_BASE_URL` the older consent
- * service targets, and holds no consent state between requests — tokens are
- * returned to the caller and passed back on the read.
+ * service targets.
+ *
+ * Consent tokens are still returned to the caller and passed back on reads and
+ * writes, but they are now also recorded server side against
+ * `(crId, locationUuid)` — see `ShrConsentSessionStore` — so
+ * `GET /shr/consents/active` can hand back a usable token without the caller
+ * orchestrating open-visits and refresh itself.
+ *
  * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
  * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-records
  */
@@ -37,38 +56,124 @@ export class ShrService {
     private readonly hieHttpRequests: HieHttpRequests,
     private readonly configService: ConfigService,
     private readonly locationFacilityHelper: LocationFacilityHelper,
+    private readonly consentSessionStore: ShrConsentSessionStore,
   ) {}
 
-  /** POST /shr/consents — ask the patient to consent to an SHR visit. */
-  async requestConsent(dto: RequestShrConsentDto) {
+  /**
+   * POST /shr/consents — ask the patient to consent to an SHR visit.
+   *
+   * Two response shapes come back and callers have to tell them apart: a
+   * standard request returns `otp_record` and no token, so an OTP step follows;
+   * an **emergency** request (`emergency: 1`) is approved on the spot and
+   * returns `consent_token` + `visit_id` with no `otp_record`, so records can be
+   * read immediately. The emergency path is the one that gets its session
+   * recorded here — the standard path gets it at verification.
+   *
+   * `practitionerId` is resolved from the logged in provider by the caller of
+   * this method, never taken from the request body, and is optional: DHA does
+   * not reject a request without it, so a resolution failure must not block a
+   * consent.
+   */
+  async requestConsent(dto: RequestShrConsentDto, practitionerId?: string) {
     const payload: ShrConsentRequestPayload = {
       cr_id: dto.crId,
       facility_id: await this.resolveFacilityCode(dto.locationUuid),
       requested_by: dto.requestedBy,
       visit_type: dto.visitType,
+      ...(practitionerId ? { practitioner_id: practitionerId } : {}),
+      ...(dto.emergency !== undefined ? { emergency: dto.emergency } : {}),
+      ...(dto.incapacityReason
+        ? { incapacity_reason: dto.incapacityReason }
+        : {}),
+      ...(dto.patientCapable !== undefined
+        ? { patient_capable: dto.patientCapable }
+        : {}),
+      ...(dto.representativeCrId
+        ? { representative_cr_id: dto.representativeCrId }
+        : {}),
+      ...(dto.representativeRelationship
+        ? { representative_relationship: dto.representativeRelationship }
+        : {}),
+      ...(dto.startDate ? { start_date: dto.startDate } : {}),
     };
-    console.log('ShrService.requestConsent payload:', payload);
-  
-    return this.post<ShrRequestConsentApiResponse>(
+
+    const response = await this.post<ShrRequestConsentApiResponse>(
       '/shr/consents',
       payload,
       dto.locationUuid,
       'request consent',
     );
+
+    // Emergency consents skip the OTP entirely, so this is the only chance to
+    // record the session for them.
+    if (response.consent_token && response.visit_id) {
+      await this.consentSessionStore.recordIssuedToken({
+        crId: dto.crId,
+        locationUuid: dto.locationUuid,
+        visitId: response.visit_id,
+        consentToken: response.consent_token,
+        consentId: response.consent_id,
+      });
+    }
+    return response;
   }
 
-  /** POST /shr/consents/{consent_id}/verify — exchange the OTP for a consent token. */
+  /**
+   * POST /shr/consents/{consent_id}/verify — records the consent decision.
+   *
+   * One call, three outcomes: an approval returns the consent token, a refusal
+   * (`consentDecision: 'Reject'`) returns the settled status with no token, and
+   * an OTP-gated closure returns `end_date`. DHA distinguishes a closure
+   * verification from a consent verification server side, from the `otpRecord`,
+   * so nothing branches on the way in.
+   */
   async verifyConsent(consentId: string, dto: VerifyShrConsentDto) {
     const payload: ShrVerifyConsentPayload = {
-      otp: dto.otp,
       otp_record: dto.otpRecord,
+      // Absent on a recorded refusal — the patient never gave a password.
+      ...(dto.otp ? { otp: dto.otp } : {}),
+      ...(dto.consentDecision ? { consent_decision: dto.consentDecision } : {}),
+      ...(dto.rejectionReason ? { rejection_reason: dto.rejectionReason } : {}),
     };
-    return this.post<ShrVerifyConsentApiResponse>(
+    const response = await this.post<ShrVerifyConsentApiResponse>(
       `/shr/consents/${encodeURIComponent(consentId)}/verify`,
       payload,
       dto.locationUuid,
       'verify consent',
     );
+
+    if (response.consent_token && response.visit_id) {
+      // `crId` is not part of DHA's contract here, so it comes from the caller
+      // when supplied and otherwise off the token's own `sub` claim. Neither
+      // being available only costs us the local session — the consent stands.
+      const crId = dto.crId ?? consentTokenSubject(response.consent_token);
+      if (crId) {
+        await this.consentSessionStore.recordIssuedToken({
+          crId,
+          locationUuid: dto.locationUuid,
+          visitId: response.visit_id,
+          consentToken: response.consent_token,
+          consentId: response.consent_id ?? consentId,
+        });
+      } else {
+        Logger.warn(
+          `Consent ${consentId} was approved but no crId was available, so no consent session was recorded. Send crId on the verify call to track it.`,
+        );
+      }
+    }
+
+    // `end_date` here means this verification completed an OTP-gated closure —
+    // the only signal that such a visit is really closed.
+    if (response.end_date) {
+      if (response.visit_id) {
+        await this.consentSessionStore.markClosedByVisit(response.visit_id);
+      } else {
+        await this.consentSessionStore.markClosedByConsent(
+          response.consent_id ?? consentId,
+        );
+      }
+    }
+    return response;
   }
 
   /** GET /shr/consents/{consent_id}/status — poll until the consent is approved. */
@@ -92,30 +197,180 @@ export class ShrService {
 
   /**
    * POST /shr/visits/{visit_id}/refresh — fresh consent token for an open visit.
-   * The current token is forwarded when the caller supplies one.
+   * The current token is forwarded when the caller supplies one, and the local
+   * session — if there is one for this visit — is updated with the new token.
    */
   async refreshVisitConsent(
     visitId: string,
     locationUuid: string,
     consentToken?: string,
   ) {
-    return this.post<ShrRefreshConsentApiResponse>(
+    const response = await this.post<ShrRefreshConsentApiResponse>(
       `/shr/visits/${encodeURIComponent(visitId)}/refresh`,
       {},
       locationUuid,
       'refresh visit consent',
       consentToken ? { [CONSENT_TOKEN_HEADER]: consentToken } : undefined,
     );
+    if (response.consent_token) {
+      await this.consentSessionStore.recordRefreshedToken(
+        visitId,
+        response.consent_token,
+      );
+    }
+    return response;
   }
 
-  /** POST /shr/visits/{visit_id}/close — end the visit. */
-  async closeVisit(visitId: string, locationUuid: string) {
-    return this.post<ShrCloseVisitApiResponse>(
+  /**
+   * POST /shr/visits/{visit_id}/close — end the visit.
+   *
+   * The body is optional in full. Omitted, closure is OTP-gated: DHA returns
+   * `otp_record` and the visit stays open until that password goes through
+   * `verifyConsent`. Sending `patientIncapable: 1` (with `incapacityReason`)
+   * closes it immediately, for a patient who cannot consent to the closure.
+   *
+   * The local session is closed only when DHA returns `end_date` — being
+   * *called* is not closure, and an OTP-gated response leaves the visit open.
+   */
+  async closeVisit(
+    visitId: string,
+    locationUuid: string,
+    dto?: CloseShrVisitDto,
+  ) {
+    const payload: ShrCloseVisitPayload = {
+      ...(dto?.patientIncapable !== undefined
+        ? { patient_incapable: dto.patientIncapable }
+        : {}),
+      ...(dto?.incapacityReason
+        ? { incapacity_reason: dto.incapacityReason }
+        : {}),
+    };
+    const response = await this.post<ShrCloseVisitApiResponse>(
       `/shr/visits/${encodeURIComponent(visitId)}/close`,
-      {},
+      payload,
       locationUuid,
       'close visit',
     );
+    if (response.end_date) {
+      await this.consentSessionStore.markClosedByVisit(visitId);
+    }
+    return response;
+  }
+
+  /**
+   * GET /shr/open-visits — the visits at this facility that still hold an open
+   * consent for the patient. An empty `visits` array means a fresh consent
+   * request is needed; anything in it can be reused via `refreshVisitConsent`
+   * instead of a second OTP.
+   */
+  async listOpenVisits(dto: ListOpenVisitsDto) {
+    const facilityId = await this.resolveFacilityCode(dto.locationUuid);
+    const encodedParams = new URLSearchParams();
+    encodedParams.set('patient_id', dto.crId);
+    encodedParams.set('facility_id', facilityId);
+    return this.get<ShrOpenVisitsApiResponse>(
+      `/shr/open-visits?${encodedParams.toString()}`,
+      dto.locationUuid,
+      'list open visits',
+    );
+  }
+
+  /**
+   * GET /shr/consents/active — one call for "give me a usable consent token for
+   * this patient here", so callers stop orchestrating open-visits + refresh
+   * themselves.
+   *
+   * In order:
+   *  1. the locally recorded session, handed back as-is when its token's own
+   *     `exp` says it is still valid
+   *  2. otherwise that session's visit refreshed against DHA — and if the
+   *     refresh is rejected, the visit is gone upstream, so the local record is
+   *     closed and we fall through
+   *  3. otherwise DHA's own open visits for the patient, refreshed and recorded
+   *
+   * `hasActiveConsent: false` is a normal answer: no open visit, so the caller
+   * needs a fresh consent request.
+   */
+  async getActiveConsent(
+    dto: GetActiveConsentDto,
+  ): Promise<ShrActiveConsentResponse> {
+    const session = await this.consentSessionStore.findOpenSession(
+      dto.crId,
+      dto.locationUuid,
+    );
+
+    if (session && isConsentTokenUsable(session.tokenExpiresAt)) {
+      return {
+        hasActiveConsent: true,
+        message: 'Active consent found',
+        source: ShrActiveConsentSource.Local,
+        visitId: session.visitId,
+        consentId: session.consentId,
+        consentToken: session.consentToken,
+        tokenExpiresAt: session.tokenExpiresAt?.toISOString() ?? null,
+      };
+    }
+
+    if (session) {
+      const refreshed = await this.tryRefreshToken(
+        session.visitId,
+        dto.locationUuid,
+        session.consentToken,
+      );
+      if (refreshed) {
+        return {
+          hasActiveConsent: true,
+          message: 'Active consent found, token refreshed',
+          source: ShrActiveConsentSource.Refreshed,
+          visitId: session.visitId,
+          consentId: session.consentId,
+          consentToken: refreshed,
+          tokenExpiresAt: consentTokenExpiry(refreshed)?.toISOString() ?? null,
+        };
+      }
+      // The visit no longer accepts a refresh, so it is closed upstream even if
+      // nothing told us. Stop handing out its token.
+      await this.consentSessionStore.markClosedByVisit(session.visitId);
+    }
+
+    const openVisits = await this.listOpenVisits({
+      crId: dto.crId,
+      locationUuid: dto.locationUuid,
+    });
+    const visitId = openVisits.visits?.[0]?.visit_id;
+    if (!visitId) {
+      return {
+        hasActiveConsent: false,
+        message:
+          'No open consent visit for this patient at this facility. Request consent first.',
+      };
+    }
+
+    const consentToken = await this.tryRefreshToken(visitId, dto.locationUuid);
+    if (!consentToken) {
+      return {
+        hasActiveConsent: false,
+        message: `Visit ${visitId} is listed as open but its consent token could not be refreshed. Request consent again.`,
+        visitId,
+      };
+    }
+
+    // `open-visits` returns visit ids only, so `consentId` stays unknown here.
+    await this.consentSessionStore.recordIssuedToken({
+      crId: dto.crId,
+      locationUuid: dto.locationUuid,
+      visitId,
+      consentToken,
+    });
+    return {
+      hasActiveConsent: true,
+      message: 'Active consent found from open visits, token refreshed',
+      source: ShrActiveConsentSource.OpenVisits,
+      visitId,
+      consentId: null,
+      consentToken,
+      tokenExpiresAt: consentTokenExpiry(consentToken)?.toISOString() ?? null,
+    };
   }
 
   /**
@@ -179,6 +434,31 @@ export class ShrService {
       dto.locationUuid,
       'fetch resource labels',
     );
+  }
+
+  /**
+   * Refresh that treats an upstream rejection as "this visit is not usable"
+   * rather than an error — `getActiveConsent` has a fallback for that, and a
+   * closed visit is a normal thing to walk into.
+   */
+  private async tryRefreshToken(
+    visitId: string,
+    locationUuid: string,
+    currentToken?: string,
+  ): Promise<string | undefined> {
+    try {
+      const response = await this.refreshVisitConsent(
+        visitId,
+        locationUuid,
+        currentToken,
+      );
+      return response.consent_token;
+    } catch (error) {
+      Logger.warn(
+        `Could not refresh consent for visit ${visitId}: ${(error as Error)?.message ?? error}`,
+      );
+      return undefined;
+    }
   }
 
   private shrBaseUrl(): string {

--- a/packages/hie-saf/src/shr/types/index.ts
+++ b/packages/hie-saf/src/shr/types/index.ts
@@ -13,20 +13,84 @@ export enum ShrVisitType {
 export enum ShrConsentStatuses {
   Pending = 'Pending',
   Approved = 'Approved',
+  Rejected = 'Rejected',
 }
 
-/** POST /shr/consents body. */
+/**
+ * DHA's `0`/`1` integer flags. Booleans are not accepted on the request side —
+ * `emergency`, `patient_capable` and `patient_incapable` are all integers.
+ */
+export enum ShrFlag {
+  No = 0,
+  Yes = 1,
+}
+
+/** `consent_decision` on the verify call. DHA also accepts the numeric forms. */
+export enum ShrConsentDecision {
+  Approve = 'Approve',
+  Reject = 'Reject',
+}
+
+/** `representative_relationship` — required whenever a representative is named. */
+export enum ShrRepresentativeRelationship {
+  HealthcareProxy = 'Healthcare Proxy',
+  Sibling = 'Sibling',
+  Principal = 'Principal',
+  Other = 'Other',
+}
+
+/**
+ * POST /shr/consents body. The same payload covers three cases:
+ *  - standard: the four required fields plus `practitioner_id`
+ *  - emergency: `emergency: 1` + `incapacity_reason`, approved on the spot
+ *  - dependant: `representative_cr_id` + `representative_relationship`, which
+ *    route the consent and its OTP to the representative
+ *
+ * `patient_capable` here is the *opposite polarity* of `patient_incapable` on
+ * `ShrCloseVisitPayload` — `patient_capable: 0` and `patient_incapable: 1` both
+ * mean "the patient cannot consent for themselves". Easy to mix up.
+ */
 export type ShrConsentRequestPayload = {
   cr_id: string;
   facility_id: string;
   requested_by: string;
   visit_type: ShrVisitType;
+  practitioner_id?: string;
+  emergency?: ShrFlag;
+  incapacity_reason?: string;
+  patient_capable?: ShrFlag;
+  representative_cr_id?: string;
+  representative_relationship?: ShrRepresentativeRelationship;
+  start_date?: string;
 };
 
-/** POST /shr/consents/{consent_id}/verify body. */
+/**
+ * POST /shr/consents/{consent_id}/verify body. No field is mandatory on its own
+ * upstream — the combination depends on the channel.
+ *
+ * `otp_record` identifies the channel and is always sent. `otp` is not: a
+ * recorded *refusal* is the case where the patient never handed over a
+ * password, so `consent_decision: 'Reject'` goes up with a
+ * `rejection_reason` and no `otp`.
+ */
 export type ShrVerifyConsentPayload = {
-  otp: string;
   otp_record: string;
+  otp?: string;
+  consent_decision?: ShrConsentDecision;
+  rejection_reason?: string;
+};
+
+/**
+ * POST /shr/visits/{visit_id}/close body — optional in full. Sent only when the
+ * patient cannot consent to the closure themselves.
+ *
+ * `patient_incapable: 1` closes the visit immediately, with no OTP. Note the
+ * polarity is inverted relative to `patient_capable` on
+ * `ShrConsentRequestPayload`, where `0` carries the same meaning.
+ */
+export type ShrCloseVisitPayload = {
+  patient_incapable?: ShrFlag;
+  incapacity_reason?: string;
 };
 
 /** GET /shr/patient-records query. */
@@ -38,7 +102,36 @@ export type ShrPatientRecordsQuery = {
   page_token?: string;
 };
 
+/** GET /shr/open-visits query. */
+export type ShrOpenVisitsQuery = {
+  patient_id: string;
+  facility_id: string;
+};
+
+/**
+ * POST /shr/consents response. A standard request returns `otp_record` and no
+ * token; an **emergency** request is approved immediately and returns
+ * `consent_token` + `visit_id` with no `otp_record`. Callers must branch on
+ * which of the two arrived rather than assuming an OTP step follows.
+ */
 export type ShrRequestConsentApiResponse = {
+  consent_id: string;
+  consent_status: string;
+  message: string;
+  status: string;
+  visit_type: string;
+  /** Only on an emergency consent, which is approved without a password. */
+  consent_token?: string;
+  /** Whether the consent was granted through the emergency route. */
+  emergency?: boolean;
+  /** Absent on an emergency consent, which needs no password. */
+  otp_record?: string;
+  /** Only on an emergency consent; a standard consent gets it at verification. */
+  visit_id?: string;
+};
+
+/** Resend echoes the consent and carries a fresh `otp_record`. */
+export type ShrResendConsentOtpApiResponse = {
   consent_id: string;
   consent_status: string;
   message: string;
@@ -47,14 +140,23 @@ export type ShrRequestConsentApiResponse = {
   visit_type: string;
 };
 
-/** Resend returns the same envelope as the initial request, with a fresh `otp_record`. */
-export type ShrResendConsentOtpApiResponse = ShrRequestConsentApiResponse;
-
+/**
+ * POST /shr/consents/{consent_id}/verify response. Three real outcomes, so
+ * everything but the envelope is optional:
+ *  - approval on the OTP channel: `consent_token` + `visit_id`
+ *  - refusal (or an approval captured off the OTP channel): `consent_id` +
+ *    `consent_status`, no token
+ *  - completion of an OTP-gated closure: `end_date`, no token
+ */
 export type ShrVerifyConsentApiResponse = {
-  consent_token: string;
   message: string;
   status: string;
-  visit_id: string;
+  consent_id?: string;
+  consent_status?: string;
+  consent_token?: string;
+  /** Only when this verification completed an OTP-gated visit closure. */
+  end_date?: string;
+  visit_id?: string;
 };
 
 export type ShrConsentStatusApiResponse = {
@@ -72,12 +174,27 @@ export type ShrRefreshConsentApiResponse = {
   status: string;
 };
 
+/**
+ * POST /shr/visits/{visit_id}/close response. `end_date` means the visit is
+ * already closed; `otp_record` means the closure is only *initiated* and the
+ * visit stays open until that password is verified through the verify endpoint.
+ */
 export type ShrCloseVisitApiResponse = {
   consent_id: string;
-  end_date: string;
   message: string;
   status: string;
   visit_id: string;
+  /** Returned on an immediate closure. */
+  end_date?: string;
+  /** Returned on an OTP-gated closure, which has *not* closed the visit yet. */
+  otp_record?: string;
+};
+
+/** GET /shr/open-visits response. An empty `visits` array means no open visit. */
+export type ShrOpenVisitsApiResponse = {
+  message: string;
+  status: string;
+  visits: { visit_id: string }[];
 };
 
 /** POST /shr/bundles response. */
@@ -89,3 +206,37 @@ export type ShrSubmitBundleApiResponse = {
 
 /** FHIR search Bundle / security labels — passed through from DHA unchanged. */
 export type ShrPassthroughResponse = Record<string, any>;
+
+/** Lifecycle of a locally tracked consent session — see `ShrConsentSession`. */
+export enum ShrConsentSessionStatus {
+  Open = 'open',
+  Closed = 'closed',
+}
+
+/** Where `GET /shr/consents/active` got the token it is handing back. */
+export enum ShrActiveConsentSource {
+  /** Straight from the local session — its token has not expired yet. */
+  Local = 'local',
+  /** Local session found, but its token was stale, so DHA refreshed it. */
+  Refreshed = 'refreshed',
+  /** No usable local session; the visit came from GET /shr/open-visits. */
+  OpenVisits = 'open-visits',
+}
+
+/**
+ * GET /shr/consents/active response — this middleware's own shape, not DHA's.
+ * `hasActiveConsent: false` is a normal answer, not an error: it means the
+ * caller must start a fresh consent request.
+ */
+export type ShrActiveConsentResponse = {
+  hasActiveConsent: boolean;
+  message: string;
+  source?: ShrActiveConsentSource;
+  visitId?: string;
+  /** Null when the session was reconstructed from `open-visits`, which
+   * returns visit ids only. */
+  consentId?: string | null;
+  consentToken?: string;
+  /** Only when the token carries an `exp` claim — see `consent-token.helper`. */
+  tokenExpiresAt?: string | null;
+};

--- a/packages/hie-saf/src/shr/utils/consent-token.helper.spec.ts
+++ b/packages/hie-saf/src/shr/utils/consent-token.helper.spec.ts
@@ -1,0 +1,72 @@
+import {
+  consentTokenExpiry,
+  consentTokenSubject,
+  decodeConsentTokenClaims,
+  isConsentTokenUsable,
+} from './consent-token.helper';
+
+/** Unsigned stand-in — nothing here verifies signatures, only reads claims. */
+const jwtWith = (claims: Record<string, unknown>) =>
+  [
+    Buffer.from(JSON.stringify({ alg: 'ES256', typ: 'JWT' })).toString(
+      'base64url',
+    ),
+    Buffer.from(JSON.stringify(claims)).toString('base64url'),
+    'signature',
+  ].join('.');
+
+describe('consent-token.helper', () => {
+  it('decodes the claims a DHA consent token actually carries', () => {
+    // Shape of the tokens in DHA's own docs: jti + sub, no exp.
+    const token = jwtWith({
+      jti: 'f9279c78-e55e-4500-a0e5-a8de141337b7',
+      sub: 'CR0824441219329-5',
+    });
+
+    expect(decodeConsentTokenClaims(token)).toEqual({
+      jti: 'f9279c78-e55e-4500-a0e5-a8de141337b7',
+      sub: 'CR0824441219329-5',
+    });
+    expect(consentTokenSubject(token)).toBe('CR0824441219329-5');
+    expect(consentTokenExpiry(token)).toBeNull();
+  });
+
+  it('returns the exp claim as a date when the token carries one', () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+
+    expect(consentTokenExpiry(jwtWith({ exp }))?.getTime()).toBe(exp * 1000);
+  });
+
+  const unreadableTokens: { label: string; token: string }[] = [
+    { label: 'an opaque token', token: 'not-a-jwt' },
+    { label: 'a payload that is not JSON', token: 'header.bm90LWpzb24.sig' },
+    { label: 'an empty token', token: '' },
+  ];
+  unreadableTokens.forEach(({ label, token }) => {
+    it(`returns no claims for ${label}`, () => {
+      expect(decodeConsentTokenClaims(token)).toBeNull();
+      expect(consentTokenExpiry(token)).toBeNull();
+      expect(consentTokenSubject(token)).toBeUndefined();
+    });
+  });
+
+  it('treats an unknown expiry as stale rather than as never expiring', () => {
+    expect(isConsentTokenUsable(null)).toBe(false);
+    expect(isConsentTokenUsable(undefined)).toBe(false);
+  });
+
+  it('reuses a token that says it is still valid and rejects one that does not', () => {
+    const now = new Date('2026-08-23T10:00:00.000Z');
+
+    expect(
+      isConsentTokenUsable(new Date('2026-08-23T11:00:00.000Z'), now),
+    ).toBe(true);
+    expect(
+      isConsentTokenUsable(new Date('2026-08-23T09:59:00.000Z'), now),
+    ).toBe(false);
+    // Inside the skew margin, so not worth handing out.
+    expect(
+      isConsentTokenUsable(new Date('2026-08-23T10:00:20.000Z'), now),
+    ).toBe(false);
+  });
+});

--- a/packages/hie-saf/src/shr/utils/consent-token.helper.ts
+++ b/packages/hie-saf/src/shr/utils/consent-token.helper.ts
@@ -1,0 +1,90 @@
+/**
+ * DHA's per-visit `consent_token` is a JWT. Nothing here verifies its
+ * signature — that is DHA's job on every read — this only reads the public
+ * claims so a stored session can tell whether its token is worth reusing.
+ *
+ * The documented example tokens decode to `{ "jti": ..., "sub": ... }` with no
+ * `exp`, so every claim below is treated as optional. A missing `exp` means
+ * "expiry unknown", never "does not expire": callers refresh instead of
+ * guessing a lifetime.
+ *
+ * @see https://hie-docs.dha.go.ke/sharedhealthrecord/shr-consent
+ */
+
+/** Claims this middleware reads off a consent token. All optional. */
+export type ConsentTokenClaims = {
+  /** Standard `exp`, seconds since the epoch. */
+  exp?: number;
+  /** The example tokens carry the patient's CR id here. */
+  sub?: string;
+  jti?: string;
+};
+
+/** Clock skew allowed before a token is treated as still usable. */
+const EXPIRY_SKEW_MS = 30_000;
+
+/**
+ * Decodes the JWT payload. Returns `null` for anything that is not a
+ * three-or-more-part JWT with a JSON payload — an opaque token is not an error,
+ * it just means no claims are available.
+ */
+export function decodeConsentTokenClaims(
+  token: string | undefined | null,
+): ConsentTokenClaims | null {
+  if (!token) {
+    return null;
+  }
+  const payload = token.split('.')[1];
+  if (!payload) {
+    return null;
+  }
+  try {
+    const decoded = Buffer.from(payload, 'base64url').toString('utf8');
+    const claims: unknown = JSON.parse(decoded);
+    if (!claims || typeof claims !== 'object') {
+      return null;
+    }
+    return claims;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The token's own expiry, or `null` when it carries no usable `exp` claim.
+ */
+export function consentTokenExpiry(
+  token: string | undefined | null,
+): Date | null {
+  const exp = decodeConsentTokenClaims(token)?.exp;
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+    return null;
+  }
+  return new Date(exp * 1000);
+}
+
+/**
+ * The patient CR id the token was issued for, when it carries one. Used only as
+ * a fallback for callers that did not send `crId` — a supplied value wins.
+ */
+export function consentTokenSubject(
+  token: string | undefined | null,
+): string | undefined {
+  const sub = decodeConsentTokenClaims(token)?.sub;
+  return typeof sub === 'string' && sub.length > 0 ? sub : undefined;
+}
+
+/**
+ * Whether a stored token can still be handed out as-is. Unknown expiry counts
+ * as stale, so the only tokens reused without a refresh are the ones that
+ * actually say they are still valid.
+ */
+export function isConsentTokenUsable(
+  expiresAt: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!expiresAt) {
+    return false;
+  }
+  return expiresAt.getTime() - EXPIRY_SKEW_MS > now.getTime();
+}


### PR DESCRIPTION
- Implemented new consent management features in the SHR service, including:
  - Requesting consent with emergency handling and session recording.
  - Verifying consent with improved handling of consent decisions and session tracking.
  - Refreshing consent tokens for open visits and managing session updates.
  - Closing visits with optional payloads for patient incapacity.
  - Listing open visits for patients to facilitate consent retrieval.
  - Fetching active consent tokens with fallback mechanisms for session management.

- Added utility functions for decoding and managing consent tokens, including:
  - Decoding JWT claims from consent tokens.
  - Checking token expiry and usability.

- Updated types to reflect new payload structures and response shapes for consent requests and verifications.
- Introduced unit tests for consent token utilities to ensure correct functionality.